### PR TITLE
New Invoice Performance Improvements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,6 +113,16 @@ sqlite3 release/app/database.db "SELECT * FROM migrations"
 - When refactoring large components: extract subcomponents and/or domain hooks first; optionally group related files in a folder with a barrel export.
 - Prefer a skeptical, high-standards approach: double check assumptions and call out issues rather than agreeing by default.
 
+## react-hook-form + Virtualization Rules
+
+The invoice line-item table uses `useFieldArray` with `react-virtuoso` (virtual rendering). This combination has critical pitfalls:
+
+1. **Never use `remove()` from useFieldArray with virtualized tables.** RHF's `remove()` updates `_fields` before `_formValues`; non-mounted FormFields (outside viewport) don't re-register after index shifts, leaving `_formValues` permanently stale. **Use `replace(filteredArray)` instead** — it atomically overwrites the full array.
+2. **`form.getValues('invoiceItems')` returns stale ARRAY after structural ops.** Per-field reads `form.getValues('invoiceItems.${i}')` are correct. Build filtered arrays by iterating `fields` (from useFieldArray) and reading each item individually.
+3. **`form.watch()` callbacks fire during useFieldArray's transitional state.** Guard structural operations (replace/append) with a `suppressWatchRef` flag so the callback doesn't read half-updated form values.
+4. **Never use `useWatch('invoiceItems')` at page level.** It subscribes to ALL field changes across ALL rows → full page re-render on every keystroke. Use `form.watch()` callback (no re-render) + selective `setState` with functional updates that skip when value unchanged.
+5. **Virtual cell keys must not include `row.index` on the outer element.** Use `key="${fieldKey}:${columnId}"` on `<TableCell>`. Put `row.index` only on the inner `<div>` (forces `useController` re-registration without full cell remount).
+
 ## Learned Workspace Facts
 
 - New Invoice screen uses domain-split hooks (inventory, next number, parties, form core, sections, resolution, discounts) rather than one useNewInvoiceForm.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "easy-accounting",
-  "version": "0.1.38",
+  "version": "0.1.39",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.1.38",
+      "version": "0.1.39",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.38",
+  "version": "0.1.39",
   "description": "Easy Accounting is a simple accounting software for SMEs.",
   "keywords": [
     "easyAccounting",

--- a/release/app/package-lock.json
+++ b/release/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "easy-accounting",
-  "version": "0.1.38",
+  "version": "0.1.39",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "easy-accounting",
-      "version": "0.1.38",
+      "version": "0.1.39",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/release/app/package.json
+++ b/release/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "easy-accounting",
-  "version": "0.1.38",
+  "version": "0.1.39",
   "description": "Easy Accounting",
   "license": "MIT",
   "author": {

--- a/src/renderer/shad/ui/dataTable.tsx
+++ b/src/renderer/shad/ui/dataTable.tsx
@@ -22,16 +22,15 @@ import {
 import { get, toString, debounce } from 'lodash';
 import { cn } from '@/renderer/lib/utils';
 import {
-  type MutableRefObject,
-  HTMLAttributes,
   forwardRef,
+  useCallback,
   useEffect,
   useLayoutEffect,
   useRef,
-  useState,
   useMemo,
+  useState,
 } from 'react';
-import { TableVirtuoso } from 'react-virtuoso';
+import { TableVirtuoso, type TableVirtuosoHandle } from 'react-virtuoso';
 import { HelpCircle } from 'lucide-react';
 import {
   Tooltip,
@@ -52,6 +51,8 @@ export type ColumnDef<TData, TValue = unknown> = ColDef<TData, TValue> & {
 interface DataTableProps<TData, TValue> extends Partial<TableOptions<TData>> {
   columns: ColDef<TData, TValue>[];
   data: TData[];
+  className?: string;
+  getRowKey?: (row: TData, index: number) => string | number;
   defaultSortField?: keyof TData;
   defaultSortDirection?: SortDirection;
   infoData?: React.ReactNode[][];
@@ -63,6 +64,7 @@ interface DataTableProps<TData, TValue> extends Partial<TableOptions<TData>> {
    * stays aligned with virtual + non-virtual tables; hidden when printing.
    */
   stickyFooterRow?: React.ReactNode[];
+  virtualScrollToIndex?: number | null;
   searchPlaceholder?: string;
   searchFields?: string[];
   isMini?: boolean;
@@ -87,56 +89,6 @@ const TableComponent = forwardRef<
   />
 ));
 TableComponent.displayName = 'TableComponent';
-
-/** virtuoso TableRow: stable when memoized with same `cellPad`; reads row from ref each paint. must forwardRef — virtuoso measures `<tr>`; missing ref breaks updates (sort looked dead). */
-const createDataTableVirtualTableRow = <TData,>(
-  rowsRef: MutableRefObject<Row<TData>[]>,
-  cellPadLocal: string,
-) => {
-  const VirtTableRow = forwardRef<
-    HTMLTableRowElement,
-    HTMLAttributes<HTMLTableRowElement>
-  >((rowProps, ref) => {
-    const { className: trClassName, style: trStyle, ...trRest } = rowProps;
-    const index = (trRest as Record<string, unknown>)['data-index'] as number;
-    const row = rowsRef.current[index];
-    if (!row) return null;
-    return (
-      <TableRow
-        ref={ref}
-        className={trClassName}
-        style={trStyle}
-        data-state={row.getIsSelected() && 'selected'}
-        {...trRest}
-      >
-        {row.getVisibleCells().map((cell) => (
-          <TableCell
-            key={cell.id}
-            className={cn(
-              cellPadLocal,
-              (cell.column.columnDef as ColumnDef<TData, unknown>)?.onClick &&
-                'cursor-pointer',
-            )}
-            style={{
-              width: cell.column.getSize(),
-              minWidth: cell.column.getSize(),
-              maxWidth: cell.column.getSize(),
-            }}
-            onClick={() =>
-              (cell.column.columnDef as ColumnDef<TData, unknown>)?.onClick?.(
-                cell.row,
-              )
-            }
-          >
-            {flexRender(cell.column.columnDef.cell, cell.getContext())}
-          </TableCell>
-        ))}
-      </TableRow>
-    );
-  });
-  VirtTableRow.displayName = 'VirtTableRow';
-  return VirtTableRow;
-};
 
 const SortingIndicator = ({ isSorted }: { isSorted: string | false }) => {
   if (!isSorted) return null;
@@ -259,12 +211,15 @@ const RecordCount = ({
 const DataTable = <TData, TValue>({
   columns,
   data,
+  className,
+  getRowKey,
   defaultSortField,
   defaultSortDirection = 'asc',
   infoData,
   virtual = false,
   compact = false,
   stickyFooterRow,
+  virtualScrollToIndex = null,
   searchPlaceholder,
   searchFields,
   isMini = false,
@@ -286,7 +241,6 @@ const DataTable = <TData, TValue>({
   });
   const [searchValue, setSearchValue] = useState('');
   const [searchInputValue, setSearchInputValue] = useState('');
-  const [filteredData, setFilteredData] = useState(data);
   const [height, setHeight] = useState(0);
   const containerRef = useRef<HTMLDivElement>(null);
   const isSearchHydratedRef = useRef(false);
@@ -329,21 +283,18 @@ const DataTable = <TData, TValue>({
     return () => window.removeEventListener('resize', calculateHeight);
   }, [virtual]);
 
-  // update filtered data when search value or data changes
-  useEffect(() => {
+  const filteredData = useMemo(() => {
     if (!searchValue || !searchFields?.length) {
-      setFilteredData(data);
-      return;
+      return data;
     }
 
     const searchTerm = searchValue.toLowerCase();
-    const filtered = data.filter((item) =>
+    return data.filter((item) =>
       searchFields.some((field) => {
         const value = get(item, field);
         return toString(value).toLowerCase().includes(searchTerm);
       }),
     );
-    setFilteredData(filtered);
   }, [searchValue, data, searchFields]);
 
   // debounced search handler
@@ -383,10 +334,17 @@ const DataTable = <TData, TValue>({
     window.electron.store.set(searchPersistenceKey, searchInputValue);
   }, [searchPersistenceKey, searchInputValue]);
 
+  const resolveRowKey = useCallback(
+    (row: TData, index: number) => getRowKey?.(row, index) ?? index,
+    [getRowKey],
+  );
+
   const table = useReactTable({
     ...restTableOptions,
     data: filteredData,
     columns,
+    getRowId: (originalRow, index) =>
+      toString(resolveRowKey(originalRow, index)),
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),
     state: {
@@ -401,16 +359,7 @@ const DataTable = <TData, TValue>({
 
   const { rows } = table.getRowModel();
 
-  const virtualRowsRef = useRef(rows);
-  virtualRowsRef.current = rows;
-  const VirtualTableRow = useMemo(
-    () =>
-      createDataTableVirtualTableRow<TData>(
-        virtualRowsRef,
-        compact ? 'py-1 px-2' : 'py-2 px-4',
-      ),
-    [compact],
-  );
+  const tableVirtuosoRef = useRef<TableVirtuosoHandle | null>(null);
 
   const tableRef = useRef(table);
   tableRef.current = table;
@@ -422,6 +371,18 @@ const DataTable = <TData, TValue>({
       tableRef.current.getRowModel().rows.map((r) => r.original),
     );
   }, [filteredData, sorting, searchValue]);
+
+  useEffect(() => {
+    if (!virtual) return;
+    if (virtualScrollToIndex == null || virtualScrollToIndex < 0) return;
+    requestAnimationFrame(() => {
+      tableVirtuosoRef.current?.scrollToIndex({
+        index: virtualScrollToIndex,
+        align: 'end',
+        behavior: 'auto',
+      });
+    });
+  }, [virtual, virtualScrollToIndex]);
 
   const recordCount = {
     filtered: rows.length,
@@ -466,6 +427,69 @@ const DataTable = <TData, TValue>({
     );
   };
 
+  const renderInfoRowsTable = () => {
+    if (!infoData?.length) return null;
+    return (
+      <div className="border-t overflow-x-auto">
+        <Table className="table-fixed">
+          <colgroup>
+            {leafHeaders.map((header) => (
+              <col key={header.id} style={{ width: header.column.getSize() }} />
+            ))}
+          </colgroup>
+          <TableBody>
+            {infoData.map((row, rowIndex) => (
+              <TableRow
+                // eslint-disable-next-line react/no-array-index-key
+                key={`virtual-info-row-${rowIndex}`}
+                className="bg-gray-50 dark:bg-gray-800 font-medium"
+              >
+                {row.map((cell, cellIndex) => (
+                  <TableCell
+                    // eslint-disable-next-line react/no-array-index-key
+                    key={`virtual-info-cell-${rowIndex}-${cellIndex}`}
+                    className={cellPad}
+                  >
+                    {cell}
+                  </TableCell>
+                ))}
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+    );
+  };
+
+  const renderVirtualItemCells = (row: Row<TData>) => {
+    const rowKey = toString(resolveRowKey(row.original, row.index));
+    const rowFormKey = `${rowKey}:${row.index}`;
+    return row.getVisibleCells().map((cell) => (
+      <TableCell
+        key={`${rowFormKey}:${cell.column.id}`}
+        className={cn(
+          cellPad,
+          (cell.column.columnDef as ColumnDef<TData, TValue>)?.onClick &&
+            'cursor-pointer',
+        )}
+        style={{
+          width: cell.column.getSize(),
+          minWidth: cell.column.getSize(),
+          maxWidth: cell.column.getSize(),
+        }}
+        onClick={() =>
+          (cell.column.columnDef as ColumnDef<TData, TValue>)?.onClick?.(
+            cell.row,
+          )
+        }
+      >
+        <div key={rowFormKey}>
+          {flexRender(cell.column.columnDef.cell, cell.getContext())}
+        </div>
+      </TableCell>
+    ));
+  };
+
   if (virtual) {
     const renderVirtualMain = () => {
       if (!rows.length) {
@@ -500,13 +524,16 @@ const DataTable = <TData, TValue>({
                 style={{ minWidth: table.getTotalSize() }}
               >
                 <TableVirtuoso
+                  ref={tableVirtuosoRef}
+                  data={rows}
                   style={{ height }}
-                  totalCount={rows.length}
-                  computeItemKey={(index) => rows[index]?.id ?? index}
+                  computeItemKey={(_, row) => (row as Row<TData>).id}
                   components={{
                     Table: TableComponent,
-                    TableRow: VirtualTableRow,
                   }}
+                  itemContent={(index, row) =>
+                    renderVirtualItemCells(row as Row<TData>)
+                  }
                   fixedHeaderContent={() =>
                     table
                       .getHeaderGroups()
@@ -529,13 +556,16 @@ const DataTable = <TData, TValue>({
       return (
         <div className="overflow-x-auto">
           <TableVirtuoso
+            ref={tableVirtuosoRef}
+            data={rows}
             style={{ height }}
-            totalCount={rows.length}
-            computeItemKey={(index) => rows[index]?.id ?? index}
+            computeItemKey={(_, row) => (row as Row<TData>).id}
             components={{
               Table: TableComponent,
-              TableRow: VirtualTableRow,
             }}
+            itemContent={(index, row) =>
+              renderVirtualItemCells(row as Row<TData>)
+            }
             fixedHeaderContent={() =>
               table
                 .getHeaderGroups()
@@ -555,7 +585,10 @@ const DataTable = <TData, TValue>({
     return (
       <div
         ref={containerRef}
-        className="rounded-md border w-full min-w-0 max-w-full flex flex-col"
+        className={cn(
+          'rounded-md border w-full min-w-0 max-w-full flex flex-col',
+          className,
+        )}
       >
         {searchFields?.length ? (
           <div className="search-container border-b shrink-0">
@@ -591,12 +624,13 @@ const DataTable = <TData, TValue>({
           </div>
         ) : null}
         {renderVirtualMain()}
+        {renderInfoRowsTable()}
       </div>
     );
   }
 
   return (
-    <div ref={containerRef} className="rounded-md border">
+    <div ref={containerRef} className={cn('rounded-md border', className)}>
       {searchFields?.length ? (
         <div className="search-container border-b">
           <div
@@ -652,7 +686,7 @@ const DataTable = <TData, TValue>({
             <>
               {rows.map((row) => (
                 <TableRow
-                  key={row.id}
+                  key={resolveRowKey(row.original, row.index)}
                   data-state={row.getIsSelected() && 'selected'}
                 >
                   {row.getVisibleCells().map((cell) => (
@@ -679,7 +713,14 @@ const DataTable = <TData, TValue>({
                       }
                     >
                       {/* HACK: Passing fields of useFieldArray as data requires field.id to be used or else it always removes only the last element https://stackoverflow.com/a/76339991/13183269 */}
-                      <div key={toString(get(cell.row.original, 'id'))}>
+                      <div
+                        key={toString(
+                          `${resolveRowKey(
+                            cell.row.original,
+                            cell.row.index,
+                          )}:${cell.row.index}`,
+                        )}
+                      >
                         {flexRender(
                           cell.column.columnDef.cell,
                           cell.getContext(),

--- a/src/renderer/shad/ui/dataTable.tsx
+++ b/src/renderer/shad/ui/dataTable.tsx
@@ -463,10 +463,13 @@ const DataTable = <TData, TValue>({
 
   const renderVirtualItemCells = (row: Row<TData>) => {
     const rowKey = toString(resolveRowKey(row.original, row.index));
+    // Cell key: stable (fieldKey + column) — React reuses the <td> across index shifts.
+    // Inner div key: fieldKey + index — forces useController re-registration when a row
+    // shifts position after a middle deletion (matches non-virtual path behavior).
     const rowFormKey = `${rowKey}:${row.index}`;
     return row.getVisibleCells().map((cell) => (
       <TableCell
-        key={`${rowFormKey}:${cell.column.id}`}
+        key={`${rowKey}:${cell.column.id}`}
         className={cn(
           cellPad,
           (cell.column.columnDef as ColumnDef<TData, TValue>)?.onClick &&

--- a/src/renderer/views/Invoice/invoiceDetails.tsx
+++ b/src/renderer/views/Invoice/invoiceDetails.tsx
@@ -277,6 +277,15 @@ export const InvoiceDetails: React.FC<InvoiceDetailsProps> = ({
   const columns: ColumnDef<InvoiceItemView>[] = useMemo(() => {
     return [
       {
+        id: 'itemNumber',
+        header: '#',
+        size: 10,
+        // eslint-disable-next-line react/no-unstable-nested-components
+        cell: ({ row }) => (
+          <span className="text-xs text-muted-foreground">{row.index + 1}</span>
+        ),
+      },
+      {
         accessorKey: 'inventoryItemName',
         header: 'Item',
       },

--- a/src/renderer/views/NewInvoice/__tests__/NewInvoicePage.date-and-submit.test.tsx
+++ b/src/renderer/views/NewInvoice/__tests__/NewInvoicePage.date-and-submit.test.tsx
@@ -338,6 +338,17 @@ describe('NewInvoicePage date confirmation + submit', () => {
   it('totalAmount <= 0: Save button is disabled', async () => {
     submitValues.totalAmount = 0;
     submitValues.accountMapping.singleAccountId = 10;
+    // total is now computed from line items, not from the form field
+    submitValues.invoiceItems = [
+      {
+        id: 1,
+        inventoryId: 1,
+        quantity: 0,
+        discount: 0,
+        price: 10,
+        discountedPrice: 0,
+      },
+    ];
     render(<NewInvoiceSaleTestHarness />);
 
     await screen.findByRole('heading', { name: /New Sale Invoice/i });

--- a/src/renderer/views/NewInvoice/__tests__/NewInvoicePage.date-and-submit.test.tsx
+++ b/src/renderer/views/NewInvoice/__tests__/NewInvoicePage.date-and-submit.test.tsx
@@ -167,8 +167,12 @@ jest.mock('../hooks/useNewInvoiceFormCore', () => ({
     const form = {
       control: {},
       formState: { isSubmitting: false, errors: {} },
-      getValues: jest.fn(() => ref),
+      getValues: jest.fn((path?: string) => {
+        if (!path) return ref;
+        return path.split('.').reduce((o: any, k: string) => o?.[k], ref);
+      }),
       setValue: jest.fn(),
+      watch: jest.fn(() => ({ unsubscribe: jest.fn() })),
       reset: jest.fn(),
       clearErrors: jest.fn(),
       handleSubmit: (onValid: (values: any) => void) => () => onValid(ref),
@@ -181,12 +185,9 @@ jest.mock('../hooks/useNewInvoiceFormCore', () => ({
       formSchema: {} as any,
       fields: ref.invoiceItems,
       append: jest.fn(),
-      watchedInvoiceItems: ref.invoiceItems,
       watchedExtraDiscount: 0,
-      watchedTotalAmount: ref.totalAmount,
       watchedSingleAccountId: ref.accountMapping?.singleAccountId,
       watchedMultipleAccountIds: [],
-      resolutionTrigger: 'x',
       discountAccountExists: true,
     };
   },

--- a/src/renderer/views/NewInvoice/__tests__/schema.test.ts
+++ b/src/renderer/views/NewInvoice/__tests__/schema.test.ts
@@ -55,10 +55,9 @@ describe('NewInvoice schema', () => {
     });
 
     expect(result.success).toBe(false);
+    // schema sets per-row errors ("X" already in row N) + root-level "Duplicate items: X"
     expect(
-      result.error?.issues.some((i) =>
-        i.message.includes('only be added once'),
-      ),
+      result.error?.issues.some((i) => i.message.includes('Duplicate items')),
     ).toBe(true);
   });
 

--- a/src/renderer/views/NewInvoice/__tests__/useNewInvoiceFormCore.test.tsx
+++ b/src/renderer/views/NewInvoice/__tests__/useNewInvoiceFormCore.test.tsx
@@ -193,6 +193,81 @@ describe('useNewInvoiceFormCore', () => {
 
       expect(result.current.fields).toHaveLength(2);
     });
+
+    it('remove deletes a row without replacing the full array', () => {
+      const refs = makeRefs();
+      const { result } = renderHook(() =>
+        useNewInvoiceFormCore({
+          invoiceType: InvoiceType.Sale,
+          inventory: sampleInventory,
+          ...refs,
+          splitByItemType: false,
+        }),
+      );
+
+      act(() => {
+        result.current.append({
+          id: 1,
+          inventoryId: 10,
+          quantity: 1,
+          discount: 0,
+          price: 100,
+          discountedPrice: 100,
+        });
+        result.current.append({
+          id: 2,
+          inventoryId: 20,
+          quantity: 3,
+          discount: 0,
+          price: 200,
+          discountedPrice: 600,
+        });
+      });
+
+      act(() => {
+        result.current.remove(0);
+      });
+
+      expect(result.current.fields).toHaveLength(1);
+      expect(result.current.watchedInvoiceItems).toEqual([
+        expect.objectContaining({ id: 2, inventoryId: 20 }),
+      ]);
+    });
+
+    it('replace updates the full row set while preserving watched invoice items', () => {
+      const refs = makeRefs();
+      const { result } = renderHook(() =>
+        useNewInvoiceFormCore({
+          invoiceType: InvoiceType.Sale,
+          inventory: sampleInventory,
+          ...refs,
+          splitByItemType: false,
+        }),
+      );
+
+      act(() => {
+        result.current.replace([
+          {
+            id: 10,
+            inventoryId: 10,
+            quantity: 5,
+            discount: 10,
+            price: 100,
+            discountedPrice: 450,
+          },
+        ]);
+      });
+
+      expect(result.current.fields).toHaveLength(1);
+      expect(result.current.watchedInvoiceItems).toEqual([
+        expect.objectContaining({
+          id: 10,
+          inventoryId: 10,
+          quantity: 5,
+          discountedPrice: 450,
+        }),
+      ]);
+    });
   });
 
   describe('watched values', () => {
@@ -235,20 +310,6 @@ describe('useNewInvoiceFormCore', () => {
       );
 
       expect(result.current.watchedExtraDiscount).toBe(0);
-    });
-
-    it('watchedTotalAmount defaults to 0', () => {
-      const refs = makeRefs();
-      const { result } = renderHook(() =>
-        useNewInvoiceFormCore({
-          invoiceType: InvoiceType.Sale,
-          inventory: sampleInventory,
-          ...refs,
-          splitByItemType: false,
-        }),
-      );
-
-      expect(result.current.watchedTotalAmount).toBe(0);
     });
 
     it('watchedSingleAccountId defaults to -1', () => {

--- a/src/renderer/views/NewInvoice/__tests__/useNewInvoiceFormCore.test.tsx
+++ b/src/renderer/views/NewInvoice/__tests__/useNewInvoiceFormCore.test.tsx
@@ -4,7 +4,7 @@
  * Coverage:
  *  - form instantiation with zod resolver for Sale & Purchase
  *  - watched invoice items, extra discount, total, account IDs
- *  - resolutionTrigger recomputes on items / split toggle
+ *  - resolutionTrigger moved to index.tsx (computed from itemStructureKey)
  *  - discountAccountExists null / true / false paths
  *  - field array append / removal
  *  - validation errors cleared on invoiceType change
@@ -158,7 +158,6 @@ describe('useNewInvoiceFormCore', () => {
       });
 
       expect(result.current.fields).toHaveLength(1);
-      expect(result.current.watchedInvoiceItems).toHaveLength(1);
     });
 
     it('append adds multiple rows', () => {
@@ -229,12 +228,13 @@ describe('useNewInvoiceFormCore', () => {
       });
 
       expect(result.current.fields).toHaveLength(1);
-      expect(result.current.watchedInvoiceItems).toEqual([
-        expect.objectContaining({ id: 2, inventoryId: 20 }),
-      ]);
+      expect(result.current.fields[0]).toMatchObject({
+        id: 2,
+        inventoryId: 20,
+      });
     });
 
-    it('replace updates the full row set while preserving watched invoice items', () => {
+    it('replace updates the full row set', () => {
       const refs = makeRefs();
       const { result } = renderHook(() =>
         useNewInvoiceFormCore({
@@ -259,45 +259,10 @@ describe('useNewInvoiceFormCore', () => {
       });
 
       expect(result.current.fields).toHaveLength(1);
-      expect(result.current.watchedInvoiceItems).toEqual([
-        expect.objectContaining({
-          id: 10,
-          inventoryId: 10,
-          quantity: 5,
-          discountedPrice: 450,
-        }),
-      ]);
     });
   });
 
   describe('watched values', () => {
-    it('watchedInvoiceItems reflects appended rows', () => {
-      const refs = makeRefs();
-      const { result } = renderHook(() =>
-        useNewInvoiceFormCore({
-          invoiceType: InvoiceType.Purchase,
-          inventory: sampleInventory,
-          ...refs,
-          splitByItemType: false,
-        }),
-      );
-
-      act(() => {
-        result.current.append({
-          id: 99,
-          inventoryId: 10,
-          quantity: 5,
-          discount: 5,
-          price: 100,
-          discountedPrice: 475,
-        });
-      });
-
-      expect(result.current.watchedInvoiceItems).toMatchObject([
-        { id: 99, inventoryId: 10 },
-      ]);
-    });
-
     it('watchedExtraDiscount defaults to 0', () => {
       const refs = makeRefs();
       const { result } = renderHook(() =>
@@ -339,78 +304,6 @@ describe('useNewInvoiceFormCore', () => {
 
       // zod default for optional array
       expect(result.current.watchedMultipleAccountIds).toEqual([]);
-    });
-  });
-
-  describe('resolutionTrigger', () => {
-    it('initially reflects empty items', () => {
-      const refs = makeRefs({ splitByItemType: true });
-      const { result } = renderHook(() =>
-        useNewInvoiceFormCore({
-          invoiceType: InvoiceType.Sale,
-          inventory: sampleInventory,
-          ...refs,
-          splitByItemType: true,
-        }),
-      );
-
-      expect(result.current.resolutionTrigger).toBe('1-0-');
-    });
-
-    it('updates when items change', () => {
-      const refs = makeRefs({ splitByItemType: true });
-      const { result } = renderHook(() =>
-        useNewInvoiceFormCore({
-          invoiceType: InvoiceType.Sale,
-          inventory: sampleInventory,
-          ...refs,
-          splitByItemType: true,
-        }),
-      );
-
-      act(() => {
-        result.current.append({
-          id: 1,
-          inventoryId: 10,
-          quantity: 1,
-          discount: 0,
-          price: 100,
-          discountedPrice: 100,
-        });
-        result.current.append({
-          id: 2,
-          inventoryId: 20,
-          quantity: 1,
-          discount: 0,
-          price: 200,
-          discountedPrice: 200,
-        });
-      });
-
-      expect(result.current.resolutionTrigger).toBe('1-2-10,20');
-    });
-
-    it('reflects split toggle even when items unchanged', () => {
-      const refs = makeRefs({ splitByItemType: false });
-      const { result, rerender } = renderHook(
-        ({ splitOff }) =>
-          useNewInvoiceFormCore({
-            invoiceType: InvoiceType.Sale,
-            inventory: sampleInventory,
-            useSingleAccountRef: refs.useSingleAccountRef,
-            splitByItemTypeRef: refs.splitByItemTypeRef,
-            splitByItemType: splitOff,
-            saleStockValidationBonusRef: refs.saleStockValidationBonusRef,
-          }),
-        { initialProps: { splitOff: false } },
-      );
-
-      const initial = result.current.resolutionTrigger;
-      rerender({ splitOff: true });
-
-      // prefix changes from 0- to 1-
-      expect(result.current.resolutionTrigger).not.toBe(initial);
-      expect(result.current.resolutionTrigger.startsWith('1-')).toBe(true);
     });
   });
 

--- a/src/renderer/views/NewInvoice/__tests__/useNewInvoiceResolution.test.tsx
+++ b/src/renderer/views/NewInvoice/__tests__/useNewInvoiceResolution.test.tsx
@@ -43,7 +43,7 @@ describe('useNewInvoiceResolution', () => {
     parties: PartyAccount[];
     inventory: InventoryItem[];
     primaryItemTypeId: number | undefined;
-    lookups: {
+    lookups?: {
       byNameAndCode?: (
         name: string,
         code?: string,
@@ -71,10 +71,10 @@ describe('useNewInvoiceResolution', () => {
     (window as any).electron = {
       getPrimaryItemType: jest.fn(async () => opts.primaryItemTypeId),
       getAccountByNameAndCode: jest.fn(
-        opts.lookups.byNameAndCode ?? (async () => undefined),
+        opts.lookups?.byNameAndCode ?? (async () => undefined),
       ),
       getAccountByNameAndChart: jest.fn(
-        opts.lookups.byNameAndChart ?? (async () => undefined),
+        opts.lookups?.byNameAndChart ?? (async () => undefined),
       ),
       getAccounts:
         opts.getAccounts ??
@@ -152,10 +152,26 @@ describe('useNewInvoiceResolution', () => {
       parties: [party],
       inventory,
       primaryItemTypeId: primaryTypeId,
-      lookups: {
-        byNameAndCode: async (_name, code) =>
-          code === 'AC-TT' ? { id: 999, name: 'Acme-TT' } : undefined,
-      },
+      getAccounts: async () => [
+        {
+          id: party.id,
+          name: party.name ?? '',
+          type: Number(party.type ?? 1),
+          code: String(party.code ?? ''),
+          chartId: party.chartId ?? 0,
+          discountProfileId: null,
+          discountProfileIsActive: null,
+        },
+        {
+          id: 999,
+          name: 'Acme-TT',
+          type: 1,
+          code: 'AC-TT',
+          chartId: party.chartId ?? 0,
+          discountProfileId: null,
+          discountProfileIsActive: null,
+        },
+      ],
       invoiceItems: [
         { id: 1, inventoryId: 100 }, // primary type => base party
         { id: 2, inventoryId: 200 }, // TT => suffixed
@@ -170,6 +186,12 @@ describe('useNewInvoiceResolution', () => {
     expect(hookResult.current.resolutionFallbacks).toEqual([]);
     expect(hookResult.current.resolvedRowLabels[0]).toBe('Acme');
     expect(hookResult.current.resolvedRowLabels[1]).toBe('Acme-TT');
+    expect(
+      (window as any).electron.getAccountByNameAndCode,
+    ).not.toHaveBeenCalled();
+    expect(
+      (window as any).electron.getAccountByNameAndChart,
+    ).not.toHaveBeenCalled();
   });
 
   it('resolves non-primary type using catalog name when inventory omits itemTypeName', async () => {
@@ -192,10 +214,26 @@ describe('useNewInvoiceResolution', () => {
         { id: 1, name: 'T' },
         { id: 2, name: 'X' },
       ],
-      lookups: {
-        byNameAndCode: async (_name, code) =>
-          code === 'AC-X' ? { id: 999, name: 'Acme-X' } : undefined,
-      },
+      getAccounts: async () => [
+        {
+          id: party.id,
+          name: party.name ?? '',
+          type: Number(party.type ?? 1),
+          code: String(party.code ?? ''),
+          chartId: party.chartId ?? 0,
+          discountProfileId: null,
+          discountProfileIsActive: null,
+        },
+        {
+          id: 999,
+          name: 'Acme-X',
+          type: 1,
+          code: 'AC-X',
+          chartId: party.chartId ?? 0,
+          discountProfileId: null,
+          discountProfileIsActive: null,
+        },
+      ],
       invoiceItems: [{ id: 1, inventoryId: 200 }],
     });
 
@@ -204,6 +242,9 @@ describe('useNewInvoiceResolution', () => {
     expect(form.getValues('accountMapping.multipleAccountIds')).toEqual([999]);
     expect(hookResult.current.resolutionFallbacks).toEqual([]);
     expect(hookResult.current.resolvedRowLabels[0]).toBe('Acme-X');
+    expect(
+      (window as any).electron.getAccountByNameAndCode,
+    ).not.toHaveBeenCalled();
   });
 
   it('falls back to chart+name lookup when name+code is not found', async () => {
@@ -217,11 +258,26 @@ describe('useNewInvoiceResolution', () => {
       parties: [party],
       inventory,
       primaryItemTypeId: 1,
-      lookups: {
-        byNameAndCode: async () => undefined,
-        byNameAndChart: async (_chartId, name) =>
-          name === 'Acme-TT' ? { id: 888, name: 'Acme-TT' } : undefined,
-      },
+      getAccounts: async () => [
+        {
+          id: party.id,
+          name: party.name ?? '',
+          type: Number(party.type ?? 1),
+          code: String(party.code ?? ''),
+          chartId: party.chartId ?? 0,
+          discountProfileId: null,
+          discountProfileIsActive: null,
+        },
+        {
+          id: 888,
+          name: 'Acme-TT',
+          type: 1,
+          code: '',
+          chartId: party.chartId ?? 0,
+          discountProfileId: null,
+          discountProfileIsActive: null,
+        },
+      ],
       invoiceItems: [{ id: 1, inventoryId: 200 }],
     });
 
@@ -230,6 +286,9 @@ describe('useNewInvoiceResolution', () => {
     expect(form.getValues('accountMapping.multipleAccountIds')).toEqual([888]);
     expect(hookResult.current.resolutionFallbacks).toEqual([]);
     expect(hookResult.current.resolvedRowLabels[0]).toBe('Acme-TT');
+    expect(
+      (window as any).electron.getAccountByNameAndChart,
+    ).not.toHaveBeenCalled();
   });
 
   it('when suffixed account is missing, falls back to base party and reports a fallback', async () => {

--- a/src/renderer/views/NewInvoice/hooks/__tests__/useNewInvoiceSections.test.tsx
+++ b/src/renderer/views/NewInvoice/hooks/__tests__/useNewInvoiceSections.test.tsx
@@ -20,7 +20,7 @@ describe('useNewInvoiceSections', () => {
         useSingleAccount: false,
         splitByItemType: false,
         form,
-        watchedInvoiceItems: [{ id: 1, inventoryId: 10 }],
+        lineItemIds: [1],
       });
       return { form, hook };
     });
@@ -50,10 +50,7 @@ describe('useNewInvoiceSections', () => {
         useSingleAccount: false,
         splitByItemType: false,
         form,
-        watchedInvoiceItems: [
-          { id: 10, inventoryId: 1 },
-          { id: 20, inventoryId: 2 },
-        ],
+        lineItemIds: [10, 20],
       });
       return { form, hook };
     });
@@ -97,7 +94,7 @@ describe('useNewInvoiceSections', () => {
         useSingleAccount: true,
         splitByItemType: false,
         form,
-        watchedInvoiceItems: [{ id: 1, inventoryId: 1 }],
+        lineItemIds: [1],
       });
       return { form, hook };
     });

--- a/src/renderer/views/NewInvoice/hooks/useNewInvoiceColumns.tsx
+++ b/src/renderer/views/NewInvoice/hooks/useNewInvoiceColumns.tsx
@@ -34,6 +34,7 @@ interface UseNewInvoiceColumnsParams<T extends FieldValues = FieldValues> {
     getValues: (name?: string) => unknown;
   };
   inventory: InventoryItem[] | undefined;
+  selectedInventoryCounts: Map<number, number>;
   invoiceType: InvoiceType;
   resolvedRowLabels: string[];
   resolvedRowCodes: string[];
@@ -88,7 +89,7 @@ interface UseNewInvoiceColumnsParams<T extends FieldValues = FieldValues> {
 interface InvoiceLineQuantityCellProps<T extends FieldValues> {
   form: { control: Control<T> };
   rowIndex: number;
-  inventory: InventoryItem[] | undefined;
+  inventoryById: Map<number, InventoryItem>;
   invoiceType: InvoiceType;
   saleStockValidationBonusRef?: React.MutableRefObject<Record<number, number>>;
   onQuantityChange: (
@@ -102,7 +103,7 @@ interface InvoiceLineQuantityCellProps<T extends FieldValues> {
 const InvoiceLineQuantityCell = <T extends FieldValues>({
   form,
   rowIndex,
-  inventory,
+  inventoryById,
   invoiceType,
   saleStockValidationBonusRef,
   onQuantityChange,
@@ -113,7 +114,7 @@ const InvoiceLineQuantityCell = <T extends FieldValues>({
     name: `invoiceItems.${rowIndex}.inventoryId` as Path<T>,
   });
   const invId = toNumber(inventoryIdWatched);
-  const inv = (inventory || []).find((i) => i.id === invId);
+  const inv = inventoryById.get(invId);
   const bonus =
     invoiceType === InvoiceType.Sale
       ? saleStockValidationBonusRef?.current[invId] ?? 0
@@ -190,6 +191,7 @@ export function useNewInvoiceColumns<T extends FieldValues>(
   const {
     form,
     inventory,
+    selectedInventoryCounts,
     invoiceType,
     resolvedRowLabels,
     resolvedRowCodes,
@@ -215,26 +217,44 @@ export function useNewInvoiceColumns<T extends FieldValues>(
   } = params;
 
   return useMemo(() => {
+    const inventoryById = new Map<number, InventoryItem>();
+    (inventory ?? []).forEach((item) => {
+      inventoryById.set(item.id, item);
+    });
+
     const getItemOptionsForRow = (rowIndex: number) => {
-      const items = (form.getValues('invoiceItems') as InvoiceItem[]) || [];
-      const selectedElsewhere = new Set<number>();
-      for (let i = 0; i < items.length; i++) {
-        if (i !== rowIndex && items[i].inventoryId > 0) {
-          selectedElsewhere.add(items[i].inventoryId);
-        }
-      }
-      return (inventory || []).filter((inv) => !selectedElsewhere.has(inv.id));
+      const currentRow = form.getValues(`invoiceItems.${rowIndex}`) as
+        | InvoiceItem
+        | undefined;
+      const currentInventoryId = toNumber(currentRow?.inventoryId);
+      return (inventory ?? []).filter((item) => {
+        const selectedCount = selectedInventoryCounts.get(item.id) ?? 0;
+        return selectedCount === 0 || item.id === currentInventoryId;
+      });
     };
 
     const baseColumns: ColumnDef<InvoiceItem>[] = [
       {
+        id: 'lineNumber',
+        header: '#',
+        size: 44,
+        minSize: 44,
+        cell: ({ row }) => (
+          <span className="text-xs tabular-nums text-muted-foreground">
+            {row.index + 1}
+          </span>
+        ),
+      },
+      {
         header: 'Item',
+        size: 360,
+        minSize: 320,
         cell: ({ row }) => (
           <FormField
             control={form.control}
             name={`invoiceItems.${row.index}.inventoryId` as Path<T>}
             render={({ field }) => (
-              <FormItem className="w-max min-w-[300px] space-y-0">
+              <FormItem className="w-full min-w-0 max-w-full space-y-0">
                 <VirtualSelect<InventoryItem>
                   options={getItemOptionsForRow(row.index)}
                   value={field.value?.toString()}
@@ -297,7 +317,7 @@ export function useNewInvoiceColumns<T extends FieldValues>(
           <InvoiceLineQuantityCell<T>
             form={form}
             rowIndex={row.index}
-            inventory={inventory}
+            inventoryById={inventoryById}
             invoiceType={invoiceType}
             saleStockValidationBonusRef={saleStockValidationBonusRef}
             onQuantityChange={onQuantityChange}
@@ -513,6 +533,7 @@ export function useNewInvoiceColumns<T extends FieldValues>(
   }, [
     form,
     inventory,
+    selectedInventoryCounts,
     invoiceType,
     resolvedRowLabels,
     resolvedRowCodes,

--- a/src/renderer/views/NewInvoice/hooks/useNewInvoiceColumns.tsx
+++ b/src/renderer/views/NewInvoice/hooks/useNewInvoiceColumns.tsx
@@ -237,8 +237,7 @@ export function useNewInvoiceColumns<T extends FieldValues>(
       {
         id: 'lineNumber',
         header: '#',
-        size: 44,
-        minSize: 44,
+        size: 30,
         cell: ({ row }) => (
           <span className="text-xs tabular-nums text-muted-foreground">
             {row.index + 1}
@@ -247,8 +246,8 @@ export function useNewInvoiceColumns<T extends FieldValues>(
       },
       {
         header: 'Item',
-        size: 360,
-        minSize: 320,
+        size: 320,
+        minSize: 280,
         cell: ({ row }) => (
           <FormField
             control={form.control}
@@ -311,8 +310,8 @@ export function useNewInvoiceColumns<T extends FieldValues>(
       },
       {
         header: 'Quantity',
-        size: 200,
-        minSize: 158,
+        size: 180,
+        minSize: 132,
         cell: ({ row }) => (
           <InvoiceLineQuantityCell<T>
             form={form}

--- a/src/renderer/views/NewInvoice/hooks/useNewInvoiceDiscounts.ts
+++ b/src/renderer/views/NewInvoice/hooks/useNewInvoiceDiscounts.ts
@@ -162,6 +162,10 @@ export function useNewInvoiceDiscounts(params: UseNewInvoiceDiscountsParams): {
     ) => {
       if (invoiceType !== InvoiceType.Sale) return;
 
+      const expectedRowId = toNumber(
+        form.getValues(`invoiceItems.${rowIndex}.id`),
+      );
+
       const resolvedInventoryId = toNumber(
         inventoryId ?? form.getValues(`invoiceItems.${rowIndex}.inventoryId`),
       );
@@ -173,6 +177,15 @@ export function useNewInvoiceDiscounts(params: UseNewInvoiceDiscountsParams): {
           accountId,
           resolvedInventoryId,
         );
+      }
+
+      if (expectedRowId > 0) {
+        const currentRowId = toNumber(
+          form.getValues(`invoiceItems.${rowIndex}.id`),
+        );
+        if (currentRowId !== expectedRowId) {
+          return;
+        }
       }
 
       const setOpts = {

--- a/src/renderer/views/NewInvoice/hooks/useNewInvoiceFormCore.ts
+++ b/src/renderer/views/NewInvoice/hooks/useNewInvoiceFormCore.ts
@@ -28,7 +28,6 @@ export function useNewInvoiceFormCore(params: UseNewInvoiceFormCoreParams) {
     inventory,
     useSingleAccountRef,
     splitByItemTypeRef,
-    splitByItemType,
     saleStockValidationBonusRef,
     isQuotationFlowRef,
   } = params;
@@ -43,6 +42,9 @@ export function useNewInvoiceFormCore(params: UseNewInvoiceFormCoreParams) {
     [invoiceType],
   );
 
+  // rebuilds zod schema when invoice type or inventory changes; uses getter refs for
+  // runtime-only flags (single account, split-by-type, quotation) so schema doesn't
+  // recompute on every checkbox toggle — only on submit when the getter is called
   const formSchema = useMemo(
     () =>
       buildNewInvoiceFormSchema({
@@ -68,18 +70,6 @@ export function useNewInvoiceFormCore(params: UseNewInvoiceFormCoreParams) {
     defaultValues: defaultFormValues,
     mode: 'onSubmit',
   });
-
-  const watchedInvoiceItems = useWatch({
-    control: form.control,
-    name: 'invoiceItems',
-  });
-
-  const resolutionTrigger = useMemo(() => {
-    const items = Array.isArray(watchedInvoiceItems) ? watchedInvoiceItems : [];
-    return `${splitByItemType ? 1 : 0}-${items.length}-${items
-      .map((i) => i?.inventoryId ?? 0)
-      .join(',')}`;
-  }, [watchedInvoiceItems, splitByItemType]);
 
   const watchedExtraDiscount = useWatch({
     control: form.control,
@@ -129,11 +119,9 @@ export function useNewInvoiceFormCore(params: UseNewInvoiceFormCoreParams) {
     append,
     remove,
     replace,
-    watchedInvoiceItems,
     watchedExtraDiscount,
     watchedSingleAccountId,
     watchedMultipleAccountIds,
-    resolutionTrigger,
     discountAccountExists,
     setDiscountAccountExists,
   };

--- a/src/renderer/views/NewInvoice/hooks/useNewInvoiceFormCore.ts
+++ b/src/renderer/views/NewInvoice/hooks/useNewInvoiceFormCore.ts
@@ -85,10 +85,6 @@ export function useNewInvoiceFormCore(params: UseNewInvoiceFormCoreParams) {
     control: form.control,
     name: 'extraDiscount',
   });
-  const watchedTotalAmount = useWatch({
-    control: form.control,
-    name: 'totalAmount',
-  });
   const watchedSingleAccountId = useWatch({
     control: form.control,
     name: 'accountMapping.singleAccountId',
@@ -119,9 +115,10 @@ export function useNewInvoiceFormCore(params: UseNewInvoiceFormCoreParams) {
       .catch(() => setDiscountAccountExists(false));
   }, [watchedExtraDiscount]);
 
-  const { fields, append } = useFieldArray({
+  const { fields, append, remove, replace } = useFieldArray({
     control: form.control,
     name: 'invoiceItems',
+    keyName: 'fieldKey',
   });
 
   return {
@@ -130,9 +127,10 @@ export function useNewInvoiceFormCore(params: UseNewInvoiceFormCoreParams) {
     formSchema,
     fields,
     append,
+    remove,
+    replace,
     watchedInvoiceItems,
     watchedExtraDiscount,
-    watchedTotalAmount,
     watchedSingleAccountId,
     watchedMultipleAccountIds,
     resolutionTrigger,

--- a/src/renderer/views/NewInvoice/hooks/useNewInvoiceInventory.ts
+++ b/src/renderer/views/NewInvoice/hooks/useNewInvoiceInventory.ts
@@ -1,6 +1,6 @@
 import { orderBy, pick, toNumber } from 'lodash';
 import type { Dispatch, SetStateAction } from 'react';
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import type { InventoryItem } from 'types';
 import { InvoiceType } from 'types';
 
@@ -87,15 +87,29 @@ export function useInvoiceInventoryLoader(
   lineInventoryIdsKey: string,
   setInventory: Dispatch<SetStateAction<InventoryItem[] | undefined>>,
 ): void {
+  const rawInventoryRef = useRef<InventoryItem[] | null>(null);
+
   useEffect(() => {
     let cancelled = false;
     const lineInventoryIds = parseLineInventoryIdsKey(lineInventoryIdsKey);
-    (async () => {
-      const raw: InventoryItem[] = await window.electron.getInventory();
+
+    const applyMergedInventory = (raw: InventoryItem[]) => {
       if (cancelled) return;
       setInventory(
         mergeInventoryForInvoice(raw, invoiceType, lineInventoryIds),
       );
+    };
+
+    (async () => {
+      if (rawInventoryRef.current) {
+        applyMergedInventory(rawInventoryRef.current);
+        return;
+      }
+
+      const raw: InventoryItem[] = await window.electron.getInventory();
+      if (cancelled) return;
+      rawInventoryRef.current = raw;
+      applyMergedInventory(raw);
     })();
     return () => {
       cancelled = true;

--- a/src/renderer/views/NewInvoice/hooks/useNewInvoiceResolution.ts
+++ b/src/renderer/views/NewInvoice/hooks/useNewInvoiceResolution.ts
@@ -27,12 +27,12 @@ const PARTY_PICK = [
   'discountProfileIsActive',
 ] as const;
 
-export interface ResolutionFallback {
+interface ResolutionFallback {
   rowIndex: number;
   expectedSuffixedName: string;
 }
 
-export interface UseNewInvoiceResolutionParams {
+interface UseNewInvoiceResolutionParams {
   invoiceType: InvoiceType;
   useSingleAccount: boolean;
   splitByItemType: boolean;
@@ -91,6 +91,10 @@ export function useNewInvoiceResolution(
   const primaryItemTypeRef = useRef<number | undefined>(undefined);
   const primaryItemTypeLoadedRef = useRef(false);
 
+  // Resolve each line-item row to a typed/suffixed customer account when split-by-item-type is on.
+  // Runs when resolutionTrigger changes (item added/removed/selected, split toggled, or header customer changes).
+  // Resolves entirely in-memory from the cached account list to avoid per-row IPC.
+  // Writes multipleAccountIds to form and fires onResolved for auto-discount.
   useEffect(() => {
     if (
       invoiceType !== InvoiceType.Sale ||

--- a/src/renderer/views/NewInvoice/hooks/useNewInvoiceResolution.ts
+++ b/src/renderer/views/NewInvoice/hooks/useNewInvoiceResolution.ts
@@ -1,5 +1,5 @@
 import { pick, toNumber, toString, trim } from 'lodash';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import type { UseFormReturn } from 'react-hook-form';
 import type { Account, InventoryItem } from 'types';
 import { InvoiceType } from 'types';
@@ -41,7 +41,7 @@ export interface UseNewInvoiceResolutionParams {
   inventory: InventoryItem[] | undefined;
   resolutionTrigger: string;
   watchedSingleAccountId: unknown;
-  onResolved?: () => void;
+  onResolved?: (changedRowIndexes: number[]) => void;
 }
 
 interface LookupRowResult {
@@ -51,6 +51,14 @@ interface LookupRowResult {
   code: string;
   fallback?: { expectedSuffixedName: string };
 }
+
+interface ItemTypeOption {
+  id: number;
+  name?: string;
+}
+
+const normalizeLookupValue = (value: unknown): string =>
+  trim(toString(value ?? '')).toLowerCase();
 
 /** when split by item type is on, resolves each row to party or suffixed account and sets multipleAccountIds + resolvedRowLabels + resolvedRowCodes */
 export function useNewInvoiceResolution(
@@ -77,6 +85,11 @@ export function useNewInvoiceResolution(
   const [resolutionFallbacks, setResolutionFallbacks] = useState<
     ResolutionFallback[]
   >([]);
+  const previousResolvedAccountByRowIdRef = useRef<Record<number, number>>({});
+  const allAccountsRef = useRef<Account[] | null>(null);
+  const itemTypesRef = useRef<ItemTypeOption[] | null>(null);
+  const primaryItemTypeRef = useRef<number | undefined>(undefined);
+  const primaryItemTypeLoadedRef = useRef(false);
 
   useEffect(() => {
     if (
@@ -89,6 +102,7 @@ export function useNewInvoiceResolution(
       setResolutionFallbacks([]);
       setResolvedRowLabels([]);
       setResolvedRowCodes([]);
+      previousResolvedAccountByRowIdRef.current = {};
       return undefined;
     }
     const singleId = toNumber(form.getValues('accountMapping.singleAccountId'));
@@ -96,17 +110,27 @@ export function useNewInvoiceResolution(
       setResolutionFallbacks([]);
       setResolvedRowLabels([]);
       setResolvedRowCodes([]);
+      previousResolvedAccountByRowIdRef.current = {};
       return undefined;
     }
 
     let cancelled = false;
 
     const runResolution = async () => {
+      const accountsPromise = allAccountsRef.current
+        ? Promise.resolve(allAccountsRef.current)
+        : window.electron.getAccounts();
+      const itemTypesPromise = itemTypesRef.current
+        ? Promise.resolve(itemTypesRef.current)
+        : window.electron.getItemTypes?.() ?? Promise.resolve([]);
+
       const [allAccountsRaw, itemTypes] = await Promise.all([
-        window.electron.getAccounts(),
-        window.electron.getItemTypes?.() ?? Promise.resolve([]),
+        accountsPromise,
+        itemTypesPromise,
       ]);
       if (cancelled) return;
+      allAccountsRef.current = allAccountsRaw;
+      itemTypesRef.current = itemTypes;
 
       const picked = allAccountsRaw.map((account: Account) =>
         pick(account, [...PARTY_PICK]),
@@ -133,10 +157,17 @@ export function useNewInvoiceResolution(
         return;
       }
 
-      const primaryId = await window.electron.getPrimaryItemType?.();
+      let primaryId = primaryItemTypeRef.current;
+      if (!primaryItemTypeLoadedRef.current) {
+        primaryId = await window.electron.getPrimaryItemType?.();
+        if (cancelled) return;
+        primaryItemTypeRef.current = primaryId;
+        primaryItemTypeLoadedRef.current = true;
+      }
       if (cancelled) return;
 
       const rows = form.getValues('invoiceItems') as Array<{
+        id?: number;
         inventoryId?: number;
         [key: string]: unknown;
       }>;
@@ -162,10 +193,30 @@ export function useNewInvoiceResolution(
         headerSuffix,
       );
 
-      const resolveOne = async (
+      const accountByNameAndCode = new Map<string, Account>();
+      const accountByChartAndName = new Map<string, Account>();
+      allAccountsRaw.forEach((account: Account) => {
+        const normalizedName = normalizeLookupValue(account.name);
+        const normalizedCode = normalizeLookupValue(account.code);
+        if (normalizedName.length > 0 && normalizedCode.length > 0) {
+          accountByNameAndCode.set(
+            `${normalizedName}::${normalizedCode}`,
+            account,
+          );
+        }
+        const normalizedChartId = toNumber(account.chartId);
+        if (normalizedChartId > 0 && normalizedName.length > 0) {
+          accountByChartAndName.set(
+            `${normalizedChartId}::${normalizedName}`,
+            account,
+          );
+        }
+      });
+
+      const resolveOne = (
         plan: SplitRowResolutionKind,
         rowIndex: number,
-      ): Promise<LookupRowResult> => {
+      ): LookupRowResult => {
         if (plan.kind === 'header') {
           return {
             rowIndex,
@@ -198,17 +249,17 @@ export function useNewInvoiceResolution(
 
         const suffixedAccount =
           expectedCode.length > 0
-            ? await window.electron.getAccountByNameAndCode(
-                partyName,
-                expectedCode,
+            ? accountByNameAndCode.get(
+                `${normalizeLookupValue(partyName)}::${normalizeLookupValue(
+                  expectedCode,
+                )}`,
               )
             : undefined;
         const chartId = toNumber(party.chartId);
         const fallbackSuffixedAccount =
           suffixedAccount?.id == null && chartId > 0
-            ? await window.electron.getAccountByNameAndChart(
-                chartId,
-                plan.suffixedName,
+            ? accountByChartAndName.get(
+                `${chartId}::${normalizeLookupValue(plan.suffixedName)}`,
               )
             : undefined;
         const resolved = suffixedAccount ?? fallbackSuffixedAccount;
@@ -237,8 +288,8 @@ export function useNewInvoiceResolution(
         };
       };
 
-      const lookupResults = await Promise.all(
-        plans.map((plan, rowIndex) => resolveOne(plan, rowIndex)),
+      const lookupResults = plans.map((plan, rowIndex) =>
+        resolveOne(plan, rowIndex),
       );
 
       if (cancelled) return;
@@ -247,10 +298,23 @@ export function useNewInvoiceResolution(
       const labels: string[] = new Array(rows.length);
       const codes: string[] = new Array(rows.length);
       const fallbacks: ResolutionFallback[] = [];
+      const nextResolvedAccountByRowId: Record<number, number> = {};
+      const changedRowIndexes: number[] = [];
+      const previousResolvedAccountByRowId =
+        previousResolvedAccountByRowIdRef.current;
       lookupResults.forEach((r) => {
         accountIds[r.rowIndex] = r.accountId;
         labels[r.rowIndex] = r.label;
         codes[r.rowIndex] = r.code;
+        const rowId = toNumber(rows[r.rowIndex]?.id);
+        if (rowId > 0) {
+          nextResolvedAccountByRowId[rowId] = r.accountId;
+          if (previousResolvedAccountByRowId[rowId] !== r.accountId) {
+            changedRowIndexes.push(r.rowIndex);
+          }
+        } else if (previousResolvedAccountByRowId[r.rowIndex] !== r.accountId) {
+          changedRowIndexes.push(r.rowIndex);
+        }
         if (r.fallback) {
           fallbacks.push({ rowIndex: r.rowIndex, ...r.fallback });
         }
@@ -264,7 +328,10 @@ export function useNewInvoiceResolution(
       setResolutionFallbacks(fallbacks);
       setResolvedRowLabels(labels);
       setResolvedRowCodes(codes);
-      onResolved?.();
+      previousResolvedAccountByRowIdRef.current = nextResolvedAccountByRowId;
+      if (changedRowIndexes.length > 0) {
+        onResolved?.(changedRowIndexes);
+      }
     };
 
     runResolution();

--- a/src/renderer/views/NewInvoice/hooks/useNewInvoiceSections.ts
+++ b/src/renderer/views/NewInvoice/hooks/useNewInvoiceSections.ts
@@ -1,19 +1,15 @@
-import { useEffect, useMemo, useState } from 'react';
+import { toNumber } from 'lodash';
+import { useEffect, useState } from 'react';
 import type { UseFormReturn } from 'react-hook-form';
 import { InvoiceType } from 'types';
 import type { CustomerSection } from '../components/CustomerSectionsBlock';
-
-interface InvoiceItemsWithId {
-  id: number;
-  [key: string]: unknown;
-}
 
 export interface UseNewInvoiceSectionsParams {
   invoiceType: InvoiceType;
   useSingleAccount: boolean;
   splitByItemType: boolean;
   form: UseFormReturn<Record<string, unknown>>;
-  watchedInvoiceItems: InvoiceItemsWithId[] | undefined;
+  lineItemIds: number[];
 }
 
 /** owns sections state and row-section mapping for multi-customer sale mode; syncs multipleAccountIds from section mapping */
@@ -27,23 +23,13 @@ export function useNewInvoiceSections(params: UseNewInvoiceSectionsParams): {
     React.SetStateAction<Record<number, string>>
   >;
 } {
-  const {
-    invoiceType,
-    useSingleAccount,
-    splitByItemType,
-    form,
-    watchedInvoiceItems,
-  } = params;
+  const { invoiceType, useSingleAccount, splitByItemType, form, lineItemIds } =
+    params;
 
   const [sections, setSections] = useState<CustomerSection[]>([]);
   const [activeSectionId, setActiveSectionId] = useState<string | null>(null);
   const [rowSectionMap, setRowSectionMap] = useState<Record<number, string>>(
     {},
-  );
-
-  const items = useMemo(
-    () => (Array.isArray(watchedInvoiceItems) ? watchedInvoiceItems : []),
-    [watchedInvoiceItems],
   );
 
   // ensure multi-customer sale mode always starts with one section selected
@@ -66,16 +52,16 @@ export function useNewInvoiceSections(params: UseNewInvoiceSectionsParams): {
       let changed = false;
       const next: Record<number, string> = {};
 
-      items.forEach((item) => {
-        const assignedSectionId = prev[item.id];
+      lineItemIds.forEach((itemId) => {
+        const assignedSectionId = prev[itemId];
         const hasAssignedSection = sections.some(
           (section) => section.id === assignedSectionId,
         );
         const targetSectionId = hasAssignedSection
           ? assignedSectionId
           : fallbackSectionId;
-        next[item.id] = targetSectionId;
-        if (prev[item.id] !== targetSectionId) {
+        next[itemId] = targetSectionId;
+        if (prev[itemId] !== targetSectionId) {
           changed = true;
         }
       });
@@ -89,7 +75,7 @@ export function useNewInvoiceSections(params: UseNewInvoiceSectionsParams): {
 
       return changed ? next : prev;
     });
-  }, [activeSectionId, invoiceType, sections, useSingleAccount, items]);
+  }, [activeSectionId, invoiceType, lineItemIds, sections, useSingleAccount]);
 
   // derive multipleAccountIds from current row-to-section customer mapping (sections mode)
   useEffect(() => {
@@ -106,8 +92,12 @@ export function useNewInvoiceSections(params: UseNewInvoiceSectionsParams): {
       return;
     }
 
-    const multipleAccountIds = items.map((item) => {
-      const sectionId = rowSectionMap[item.id];
+    const currentItems = form.getValues('invoiceItems') as Array<{
+      id?: number;
+    }>;
+    const multipleAccountIds = currentItems.map((item, index) => {
+      const itemId = toNumber(item?.id ?? lineItemIds[index]);
+      const sectionId = rowSectionMap[itemId];
       const section = sections.find((entry) => entry.id === sectionId);
       return section?.accountId && section.accountId > 0
         ? section.accountId
@@ -128,7 +118,7 @@ export function useNewInvoiceSections(params: UseNewInvoiceSectionsParams): {
     sections,
     splitByItemType,
     useSingleAccount,
-    items,
+    lineItemIds,
   ]);
 
   return {

--- a/src/renderer/views/NewInvoice/hooks/useNewInvoiceTableInfo.tsx
+++ b/src/renderer/views/NewInvoice/hooks/useNewInvoiceTableInfo.tsx
@@ -22,7 +22,11 @@ interface UseNewInvoiceTableInfoParams<T extends FieldValues = FieldValues> {
   invoiceType: InvoiceType;
   watchedExtraDiscount: unknown;
   watchedTotalAmount: unknown;
-  extraDiscountAccountOptions: Array<{ id: number; name: string }>;
+  extraDiscountAccountOptions: Array<{
+    id: number;
+    name: string;
+    code?: string;
+  }>;
   discountAccountExists: boolean | null;
   enableCumulativeDiscount: boolean;
   setEnableCumulativeDiscount: (value: boolean) => void;
@@ -31,6 +35,7 @@ interface UseNewInvoiceTableInfoParams<T extends FieldValues = FieldValues> {
   onCumulativeDiscountChange: (value: string) => void;
   useSingleAccount: boolean;
   splitByItemType: boolean;
+  includeRowNumberColumn?: boolean;
 }
 
 /** returns table footer rows (extra discount, extra discount account, total; optionally cumulative discount) for the invoice DataTable infoData */
@@ -51,6 +56,7 @@ export function useNewInvoiceTableInfo<T extends FieldValues>(
     onCumulativeDiscountChange,
     useSingleAccount,
     splitByItemType,
+    includeRowNumberColumn = false,
   } = params;
 
   return useMemo(() => {
@@ -110,7 +116,11 @@ export function useNewInvoiceTableInfo<T extends FieldValues>(
                 render={({ field }) => (
                   <FormItem>
                     <FormControl>
-                      <VirtualSelect<{ id: number; name: string }>
+                      <VirtualSelect<{
+                        id: number;
+                        name: string;
+                        code?: string;
+                      }>
                         options={extraDiscountAccountOptions}
                         value={field.value ?? null}
                         onChange={(val) =>
@@ -119,6 +129,36 @@ export function useNewInvoiceTableInfo<T extends FieldValues>(
                         placeholder="Select account"
                         searchPlaceholder="Search accounts..."
                         disabled={extraDiscountAccountOptions.length === 0}
+                        renderTriggerValue={({ selected, placeholder }) =>
+                          selected ? (
+                            <span className="flex w-full min-w-0 items-center justify-between gap-2 px-3 py-2 text-sm">
+                              <span className="min-w-0 truncate">
+                                {selected.name}
+                              </span>
+                              {selected.code ? (
+                                <span className="shrink-0 text-xs font-mono text-muted-foreground">
+                                  {selected.code}
+                                </span>
+                              ) : null}
+                            </span>
+                          ) : (
+                            <span className="px-3 text-muted-foreground">
+                              {placeholder}
+                            </span>
+                          )
+                        }
+                        renderSelectItem={(item) => (
+                          <div className="flex min-w-[220px] items-center justify-between gap-2">
+                            <span className="min-w-0 truncate text-sm">
+                              {item.name}
+                            </span>
+                            {item.code ? (
+                              <span className="shrink-0 text-xs font-mono text-muted-foreground">
+                                {item.code}
+                              </span>
+                            ) : null}
+                          </div>
+                        )}
                       />
                     </FormControl>
                     {discountAccountExists === false && (
@@ -206,9 +246,11 @@ export function useNewInvoiceTableInfo<T extends FieldValues>(
       ]);
     }
 
-    return rows.map((row) =>
-      useSingleAccount && !splitByItemType ? row : [...row, null],
-    );
+    return rows.map((row) => {
+      const alignedRow =
+        useSingleAccount && !splitByItemType ? row : [...row, null];
+      return includeRowNumberColumn ? [null, ...alignedRow] : alignedRow;
+    });
   }, [
     control,
     invoiceType,
@@ -223,5 +265,6 @@ export function useNewInvoiceTableInfo<T extends FieldValues>(
     onCumulativeDiscountChange,
     useSingleAccount,
     splitByItemType,
+    includeRowNumberColumn,
   ]);
 }

--- a/src/renderer/views/NewInvoice/index.tsx
+++ b/src/renderer/views/NewInvoice/index.tsx
@@ -108,7 +108,6 @@ interface NewInvoiceProps {
   invoiceType: InvoiceType;
 }
 
-// TODO: improve performance, check states: remove unnecessary data
 const NewInvoicePage: React.FC<NewInvoiceProps> = ({
   invoiceType,
 }: NewInvoiceProps) => {
@@ -199,29 +198,31 @@ const NewInvoicePage: React.FC<NewInvoiceProps> = ({
     formSchema,
     fields,
     append,
-    remove,
     replace,
-    watchedInvoiceItems,
     watchedExtraDiscount,
     watchedSingleAccountId,
     watchedMultipleAccountIds,
-    resolutionTrigger,
     discountAccountExists,
   } = formCore;
 
-  const normalizedInvoiceItems = useMemo(
-    () => (Array.isArray(watchedInvoiceItems) ? watchedInvoiceItems : []),
-    [watchedInvoiceItems],
-  );
+  // ── Derived invoice-item state via form.watch() callback ──
+  // Replaces useWatch('invoiceItems') which caused full page re-renders on every keystroke.
+  // form.watch callback fires WITHOUT re-rendering; we only setState when a derived value actually changes, so the page re-renders only when structure or total changes.
+  const [itemStructureKey, setItemStructureKey] = useState('');
+  const [computedTotalAmount, setComputedTotalAmount] = useState(0);
 
+  // sorted+deduped key for the inventory loader; derived from itemStructureKey so it only triggers a fetch when the set of selected items changes, not on qty/price edits
   const lineInventoryIdsKey = useMemo(
     () =>
       lineInventoryIdsKeyFromIds(
-        normalizedInvoiceItems
-          .map((row) => toNumber(row?.inventoryId))
-          .filter((id) => id > 0),
+        itemStructureKey
+          ? itemStructureKey
+              .split(',')
+              .map(Number)
+              .filter((id) => id > 0)
+          : [],
       ),
-    [normalizedInvoiceItems],
+    [itemStructureKey],
   );
 
   useInvoiceInventoryLoader(invoiceType, lineInventoryIdsKey, setInventory);
@@ -234,26 +235,24 @@ const NewInvoicePage: React.FC<NewInvoiceProps> = ({
     return next;
   }, [inventory]);
 
-  // string-stable key: only changes when which items are selected changes, not on quantity/price edits.
-  // useMemo recalculates every render but the primitive string output is compared by value downstream,
-  // so selectedInventoryCounts stays ref-stable across quantity edits → columns stay stable → focus preserved.
-  const inventorySelectionKey = useMemo(
-    () =>
-      normalizedInvoiceItems.map((row) => toNumber(row?.inventoryId)).join(','),
-    [normalizedInvoiceItems],
-  );
-
+  // how many times each inventory item is used across rows; drives available-item filtering in the item selector so the same item can't be picked twice
   const selectedInventoryCounts = useMemo(() => {
     const counts = new Map<number, number>();
-    normalizedInvoiceItems.forEach((row) => {
-      const inventoryId = toNumber(row?.inventoryId);
-      if (inventoryId <= 0) return;
-      counts.set(inventoryId, (counts.get(inventoryId) ?? 0) + 1);
+    if (!itemStructureKey) return counts;
+    itemStructureKey.split(',').forEach((idStr) => {
+      const id = Number(idStr);
+      if (id > 0) counts.set(id, (counts.get(id) ?? 0) + 1);
     });
     return counts;
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [inventorySelectionKey]);
+  }, [itemStructureKey]);
 
+  // encodes split mode + item count + inventoryIds; useNewInvoiceResolution re-runs only when this string changes, avoiding per-keystroke IPC fan-out
+  const resolutionTrigger = useMemo(
+    () => `${splitByItemType ? 1 : 0}-${fields.length}-${itemStructureKey}`,
+    [splitByItemType, fields.length, itemStructureKey],
+  );
+
+  // business row IDs (not fieldKeys) for section-mapping sync in useNewInvoiceSections
   const lineItemIds = useMemo(
     () =>
       fields
@@ -319,6 +318,104 @@ const NewInvoicePage: React.FC<NewInvoiceProps> = ({
     sectionAutoDiscountOffCount,
     getSectionLabel,
   } = discounts;
+
+  // ── derived invoice-item state via form.watch() ──
+  // WHY form.watch instead of useWatch? useWatch('invoiceItems') re-renders the entire page on every field change across all rows (qty, price, discount, etc.).
+  // form.watch fires a callback WITHOUT re-rendering.
+  // We only setState when a derived value actually changes, and debounce total updates so fast typing batches into one re-render.
+  // IMPORTANT: the callback is suppressed during useFieldArray.remove() via suppressWatchRef to prevent form.getValues reading stale _formValues that RHF hasn't finished shifting yet.
+  const totalDebounceRef = useRef<ReturnType<typeof setTimeout>>();
+  const suppressWatchRef = useRef(false);
+
+  const recomputeDerivedState = useCallback(
+    (immediate = false) => {
+      const raw = form.getValues('invoiceItems');
+      const items = (Array.isArray(raw) ? raw : []) as Array<{
+        id?: number;
+        inventoryId?: number;
+        quantity?: number;
+        price?: number;
+        discount?: number;
+        discountedPrice?: number;
+      }>;
+
+      const newKey = items.map((i) => toNumber(i?.inventoryId)).join(',');
+      setItemStructureKey((prev) => (prev === newKey ? prev : newKey));
+
+      const hasActive = items.some((i) => toNumber(i?.quantity) > 0);
+
+      let newTotal = 0;
+      if (hasActive) {
+        const sectionSums = items.reduce(
+          (acc, item) => {
+            const sectionKey = rowSectionMap[toNumber(item?.id)] || 'No Type';
+            const amount =
+              enableCumulativeDiscount && cumulativeDiscount
+                ? computeInvoiceItemTotal(
+                    toNumber(item?.quantity),
+                    cumulativeDiscount,
+                    toNumber(item?.price),
+                  )
+                : toNumber(item?.discountedPrice);
+            acc[sectionKey] =
+              (acc[sectionKey] ?? 0) + (Number.isFinite(amount) ? amount : 0);
+            return acc;
+          },
+          {} as Record<string, number>,
+        );
+        const grossRounded = Object.values(sectionSums).reduce(
+          (sum, s) => sum + Math.round(toNumber(s)),
+          0,
+        );
+        newTotal = grossRounded - toNumber(watchedExtraDiscount ?? 0);
+      }
+
+      const syncTotal = () => {
+        form.setValue('totalAmount', newTotal, {
+          shouldValidate: false,
+          shouldDirty: true,
+        });
+        setComputedTotalAmount((prev) => (prev === newTotal ? prev : newTotal));
+      };
+      if (immediate) {
+        syncTotal();
+      } else {
+        clearTimeout(totalDebounceRef.current);
+        totalDebounceRef.current = setTimeout(syncTotal, 150);
+      }
+    },
+    [
+      form,
+      enableCumulativeDiscount,
+      cumulativeDiscount,
+      watchedExtraDiscount,
+      rowSectionMap,
+    ],
+  );
+
+  // subscribe to invoiceItems changes
+  useEffect(() => {
+    recomputeDerivedState(true);
+    const sub = form.watch((_values, { name }) => {
+      // suppressWatchRef is set during replace() in handleRemoveRow to avoid reading RHF's transitional _formValues.
+      if (suppressWatchRef.current) {
+        return;
+      }
+      // fires on form.reset (Clear button)
+      if (name == null) {
+        recomputeDerivedState(true);
+        return;
+      }
+      // fires on field edits
+      if (name.startsWith('invoiceItems')) {
+        recomputeDerivedState(false);
+      }
+    });
+    return () => {
+      sub.unsubscribe();
+      clearTimeout(totalDebounceRef.current);
+    };
+  }, [form, recomputeDerivedState]);
 
   const onResolved = useCallback(
     (changedRowIndexes: number[]) => {
@@ -467,7 +564,7 @@ const NewInvoicePage: React.FC<NewInvoiceProps> = ({
     useSingleAccount,
     splitByItemType,
     watchedSingleAccountId,
-    watchedInvoiceItems,
+    itemStructureKey,
     inventory,
     form,
   ]);
@@ -695,81 +792,47 @@ const NewInvoicePage: React.FC<NewInvoiceProps> = ({
 
   const handleRemoveRow = useCallback(
     (rowIndex: number) => {
-      const invoiceItems = form.getValues('invoiceItems');
-      const removedRow = invoiceItems[rowIndex];
-      if (!removedRow || fields.length === 0) return;
+      if (rowIndex >= fields.length || fields.length === 0) return;
+      const removedRow = fields[rowIndex];
+      const removedId = toNumber(get(removedRow, 'id'));
 
+      // Use replace() instead of remove(). RHF's remove() updates _fields
+      // before _formValues, and virtualized (non-mounted) FormFields don't
+      // re-register after index shifts — leaving _formValues permanently stale.
+      // replace() writes the full array atomically, bypassing both issues.
+      suppressWatchRef.current = true;
+      const kept = [];
+      for (let i = 0; i < fields.length; i += 1) {
+        if (i !== rowIndex) kept.push(form.getValues(`invoiceItems.${i}`));
+      }
       form.clearErrors(`invoiceItems.${rowIndex}` as const);
-      remove(rowIndex);
-      if (removedRow.id) {
+      replace(kept);
+      suppressWatchRef.current = false;
+
+      requestAnimationFrame(() => recomputeDerivedState(true));
+
+      if (removedId > 0) {
         setRowSectionMap((prev) => {
           const next = { ...prev };
-          delete next[removedRow.id];
+          delete next[removedId];
           return next;
         });
         setManualDiscountRows((prev) => {
           const next = { ...prev };
-          delete next[removedRow.id];
+          delete next[removedId];
           return next;
         });
       }
     },
-    [fields.length, form, remove, setManualDiscountRows, setRowSectionMap],
+    [
+      fields,
+      form,
+      recomputeDerivedState,
+      replace,
+      setManualDiscountRows,
+      setRowSectionMap,
+    ],
   );
-
-  /** has item + its quantity selected */
-  const hasActiveInvoiceItem = useMemo(
-    () => normalizedInvoiceItems.some((item) => toNumber(item?.quantity) > 0),
-    [normalizedInvoiceItems],
-  );
-
-  // compute total synchronously (useMemo) so the display updates in the SAME render cycle
-  // instead of useEffect → form.setValue → useWatch → second render.
-  const computedTotalAmount = useMemo(() => {
-    if (!hasActiveInvoiceItem) return 0;
-
-    const sectionSums = normalizedInvoiceItems.reduce(
-      (acc, item) => {
-        const key = rowSectionMap[item.id] || 'No Type';
-        const amount =
-          enableCumulativeDiscount && cumulativeDiscount
-            ? computeInvoiceItemTotal(
-                item.quantity,
-                cumulativeDiscount,
-                item.price,
-              )
-            : toNumber(item.discountedPrice);
-        const safeAmount = Number.isFinite(amount) ? amount : 0;
-        acc[key] = (acc[key] ?? 0) + safeAmount;
-        return acc;
-      },
-      {} as Record<string, number>,
-    );
-
-    const grossRounded = Object.values(sectionSums).reduce((sumRupees, s) => {
-      return sumRupees + Math.round(toNumber(s));
-    }, 0);
-    return grossRounded - toNumber(watchedExtraDiscount ?? 0);
-  }, [
-    cumulativeDiscount,
-    enableCumulativeDiscount,
-    hasActiveInvoiceItem,
-    watchedExtraDiscount,
-    normalizedInvoiceItems,
-    rowSectionMap,
-  ]);
-
-  // sync computed total to form field for validation/submission; this does NOT trigger a
-  // re-render via useWatch because we removed the watchedTotalAmount subscription.
-  const prevTotalRef = useRef<number>(0);
-  useEffect(() => {
-    if (computedTotalAmount === prevTotalRef.current) return;
-    prevTotalRef.current = computedTotalAmount;
-    form.setValue('totalAmount', computedTotalAmount, {
-      shouldValidate: false,
-      shouldDirty: true,
-    });
-  }, [computedTotalAmount, form]);
 
   const getSelectedItem = useCallback(
     (fieldValue: number) => inventoryById.get(toNumber(fieldValue)),
@@ -887,13 +950,18 @@ const NewInvoicePage: React.FC<NewInvoiceProps> = ({
     [form, invoiceType, recalculateAutoDiscounts],
   );
 
-  // focus intent: set before append, consumed by useLayoutEffect AFTER React mounts new row
+  // ── new-row focus + scroll ──
+  // WHY refs+layoutEffect instead of direct focus: append() triggers React state updates;
+  // the new row's DOM doesn't exist yet when append returns. pendingItemFocusRef stores
+  // the target index, and the useLayoutEffect below fires AFTER React commits the new row
+  // to DOM, at which point the VirtualSelect trigger input can be found and focused.
   const pendingItemFocusRef = useRef<number | null>(null);
-  // scroll virtualized table to newly added row so it mounts before focus
+  // scroll virtuoso to the new row so it mounts in the visible range before focus
   const [virtualScrollToIndex, setVirtualScrollToIndex] = useState<
     number | null
   >(null);
 
+  // sets pendingItemFocusRef for auto-focus
   const handleAddNewRow = useCallback(() => {
     const entry = getInitialEntry();
     const newRowIndex = fields.length;
@@ -920,16 +988,17 @@ const NewInvoicePage: React.FC<NewInvoiceProps> = ({
     useSingleAccount,
   ]);
 
-  // after React commits new row to DOM, schedule focus on its item field
+  // fires after React commits the new row — runs before paint (useLayoutEffect) so the focus schedule starts as early as possible
+  // fields.length changes on append/remove.
   useLayoutEffect(() => {
     const rowIndex = pendingItemFocusRef.current;
     if (rowIndex == null) return;
     pendingItemFocusRef.current = null;
     scheduleItemFieldFocusAfterNewRow(form, rowIndex);
-    // clear scroll-to so it doesn't re-trigger on unrelated re-renders
     setVirtualScrollToIndex(null);
   }, [fields.length, form]);
 
+  // `enter` in quantity: commit the current value, recalculate discountedPrice, then append a new row
   const onQuantityEnterAddRow = useCallback(
     (rowIndex: number) => {
       const qPath = `invoiceItems.${rowIndex}.quantity` as Path<Invoice>;
@@ -1021,10 +1090,8 @@ const NewInvoicePage: React.FC<NewInvoiceProps> = ({
     [],
   );
 
-  // Memoize DataTable element so React skips its entire reconciliation subtree
-  // when the page re-renders due to watchedInvoiceItems/total changes.
-  // During typing: columns (stable), fields (stable from useFieldArray),
-  // virtualScrollToIndex (null) are unchanged → memo reused → zero DataTable cost.
+  // memoize DataTable element so React skips its entire reconciliation subtree when the page re-renders due to total/structural changes.
+  // during typing: columns (stable), fields (stable from useFieldArray), virtualScrollToIndex (null) are unchanged → memo reused → zero DataTable cost.
   const lineItemTableElement = useMemo(
     () => (
       <DataTable

--- a/src/renderer/views/NewInvoice/index.tsx
+++ b/src/renderer/views/NewInvoice/index.tsx
@@ -1,7 +1,14 @@
 /* eslint-disable react/no-unstable-nested-components */
 import { get, isNil, pick, toNumber, toString } from 'lodash';
 import { Plus, Printer, RefreshCw, Upload } from 'lucide-react';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import type { Path, UseFormReturn } from 'react-hook-form';
 import { useFormState, useWatch } from 'react-hook-form';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
@@ -11,6 +18,10 @@ import {
   getFormattedCurrency,
   raise,
 } from 'renderer/lib/utils';
+import {
+  currencyFormatOptions,
+  DISCOUNT_ACCOUNT_NAME,
+} from 'renderer/lib/constants';
 import { Button } from 'renderer/shad/ui/button';
 import { getOsModifierLabel } from '@/renderer/shad/ui/kbd';
 import {
@@ -91,7 +102,6 @@ import { useNewInvoiceNextNumber } from './hooks/useNewInvoiceNextNumber';
 import { useNewInvoiceParties } from './hooks/useNewInvoiceParties';
 import { useNewInvoiceResolution } from './hooks/useNewInvoiceResolution';
 import { useNewInvoiceSections } from './hooks/useNewInvoiceSections';
-import { useNewInvoiceTableInfo } from './hooks/useNewInvoiceTableInfo';
 import type { PartyAccount } from './hooks/useNewInvoiceParties';
 
 interface NewInvoiceProps {
@@ -189,26 +199,68 @@ const NewInvoicePage: React.FC<NewInvoiceProps> = ({
     formSchema,
     fields,
     append,
+    remove,
+    replace,
     watchedInvoiceItems,
     watchedExtraDiscount,
-    watchedTotalAmount,
     watchedSingleAccountId,
     watchedMultipleAccountIds,
     resolutionTrigger,
     discountAccountExists,
   } = formCore;
 
-  const lineInventoryIdsKey = useMemo(
-    () =>
-      lineInventoryIdsKeyFromIds(
-        (watchedInvoiceItems ?? [])
-          .map((row) => toNumber(row?.inventoryId))
-          .filter((id) => id > 0),
-      ),
+  const normalizedInvoiceItems = useMemo(
+    () => (Array.isArray(watchedInvoiceItems) ? watchedInvoiceItems : []),
     [watchedInvoiceItems],
   );
 
+  const lineInventoryIdsKey = useMemo(
+    () =>
+      lineInventoryIdsKeyFromIds(
+        normalizedInvoiceItems
+          .map((row) => toNumber(row?.inventoryId))
+          .filter((id) => id > 0),
+      ),
+    [normalizedInvoiceItems],
+  );
+
   useInvoiceInventoryLoader(invoiceType, lineInventoryIdsKey, setInventory);
+
+  const inventoryById = useMemo(() => {
+    const next = new Map<number, InventoryItem>();
+    (inventory ?? []).forEach((item) => {
+      next.set(item.id, item);
+    });
+    return next;
+  }, [inventory]);
+
+  // string-stable key: only changes when which items are selected changes, not on quantity/price edits.
+  // useMemo recalculates every render but the primitive string output is compared by value downstream,
+  // so selectedInventoryCounts stays ref-stable across quantity edits → columns stay stable → focus preserved.
+  const inventorySelectionKey = useMemo(
+    () =>
+      normalizedInvoiceItems.map((row) => toNumber(row?.inventoryId)).join(','),
+    [normalizedInvoiceItems],
+  );
+
+  const selectedInventoryCounts = useMemo(() => {
+    const counts = new Map<number, number>();
+    normalizedInvoiceItems.forEach((row) => {
+      const inventoryId = toNumber(row?.inventoryId);
+      if (inventoryId <= 0) return;
+      counts.set(inventoryId, (counts.get(inventoryId) ?? 0) + 1);
+    });
+    return counts;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [inventorySelectionKey]);
+
+  const lineItemIds = useMemo(
+    () =>
+      fields
+        .map((field) => toNumber(get(field, 'id')))
+        .filter((rowId) => rowId > 0),
+    [fields],
+  );
 
   const { isDirty, errors: formErrors } = useFormState({
     control: form.control,
@@ -239,7 +291,7 @@ const NewInvoicePage: React.FC<NewInvoiceProps> = ({
     useSingleAccount,
     splitByItemType,
     form: form as unknown as UseFormReturn<Record<string, unknown>>,
-    watchedInvoiceItems,
+    lineItemIds,
   });
 
   const discounts = useNewInvoiceDiscounts({
@@ -256,7 +308,6 @@ const NewInvoicePage: React.FC<NewInvoiceProps> = ({
   const {
     applyAutoDiscountForRow,
     recalculateAutoDiscounts,
-    recalculateAutoDiscountsRef,
     manualDiscountRows,
     setManualDiscountRows,
     enableCumulativeDiscount,
@@ -269,9 +320,17 @@ const NewInvoicePage: React.FC<NewInvoiceProps> = ({
     getSectionLabel,
   } = discounts;
 
-  const onResolved = useCallback(() => {
-    recalculateAutoDiscountsRef.current();
-  }, [recalculateAutoDiscountsRef]);
+  const onResolved = useCallback(
+    (changedRowIndexes: number[]) => {
+      if (!changedRowIndexes.length) return;
+      Promise.all(
+        changedRowIndexes.map((rowIndex) => applyAutoDiscountForRow(rowIndex)),
+      ).catch((error) => {
+        console.error('Error applying auto discount after resolution', error);
+      });
+    },
+    [applyAutoDiscountForRow],
+  );
 
   const { resolvedRowLabels, resolvedRowCodes, resolutionFallbacks } =
     useNewInvoiceResolution({
@@ -591,12 +650,23 @@ const NewInvoicePage: React.FC<NewInvoiceProps> = ({
             ]
           : undefined) ??
         `Account ${id}`;
-      return { id, name: label };
+      const partyCode =
+        party?.code != null ? String(party.code).trim() : undefined;
+      const resolvedCode =
+        Array.isArray(resolvedRowCodes) &&
+        typeof watchedMultipleAccountIds?.indexOf === 'function'
+          ? resolvedRowCodes[
+              (watchedMultipleAccountIds as number[]).indexOf(id)
+            ]
+          : undefined;
+      const code = partyCode && partyCode.length > 0 ? partyCode : resolvedCode;
+      return { id, name: label, code };
     });
   }, [
     invoiceType,
     parties,
     resolvedRowLabels,
+    resolvedRowCodes,
     splitByItemType,
     useSingleAccount,
     watchedExtraDiscount,
@@ -625,49 +695,40 @@ const NewInvoicePage: React.FC<NewInvoiceProps> = ({
 
   const handleRemoveRow = useCallback(
     (rowIndex: number) => {
-      const latestInvoice = form.getValues();
-      const removedRow = latestInvoice.invoiceItems[rowIndex];
+      const invoiceItems = form.getValues('invoiceItems');
+      const removedRow = invoiceItems[rowIndex];
+      if (!removedRow || fields.length === 0) return;
 
-      if (fields.length > 0) {
-        form.clearErrors(`invoiceItems.${rowIndex}` as const);
-        form.setValue(
-          'invoiceItems',
-          latestInvoice.invoiceItems.filter((_, index) => index !== rowIndex),
-        );
-        if (removedRow?.id) {
-          setRowSectionMap((prev) => {
-            const next = { ...prev };
-            delete next[removedRow.id];
-            return next;
-          });
-          setManualDiscountRows((prev) => {
-            const next = { ...prev };
-            delete next[removedRow.id];
-            return next;
-          });
-        }
+      form.clearErrors(`invoiceItems.${rowIndex}` as const);
+      remove(rowIndex);
+      if (removedRow.id) {
+        setRowSectionMap((prev) => {
+          const next = { ...prev };
+          delete next[removedRow.id];
+          return next;
+        });
+        setManualDiscountRows((prev) => {
+          const next = { ...prev };
+          delete next[removedRow.id];
+          return next;
+        });
       }
     },
-    [fields.length, form, setManualDiscountRows, setRowSectionMap],
+    [fields.length, form, remove, setManualDiscountRows, setRowSectionMap],
   );
 
   /** has item + its quantity selected */
   const hasActiveInvoiceItem = useMemo(
-    () => !!watchedInvoiceItems.at(0)?.discountedPrice,
-    [watchedInvoiceItems],
+    () => normalizedInvoiceItems.some((item) => toNumber(item?.quantity) > 0),
+    [normalizedInvoiceItems],
   );
 
-  // keep form totalAmount aligned with line items: sum per-section amounts (rounded per section), optional cumulative discount path, minus extra discount — matches what we post and show
-  useEffect(() => {
-    if (!hasActiveInvoiceItem) {
-      form.setValue('totalAmount', 0, {
-        shouldValidate: false,
-        shouldDirty: true,
-      });
-      return;
-    }
+  // compute total synchronously (useMemo) so the display updates in the SAME render cycle
+  // instead of useEffect → form.setValue → useWatch → second render.
+  const computedTotalAmount = useMemo(() => {
+    if (!hasActiveInvoiceItem) return 0;
 
-    const sectionSums = watchedInvoiceItems.reduce(
+    const sectionSums = normalizedInvoiceItems.reduce(
       (acc, item) => {
         const key = rowSectionMap[item.id] || 'No Type';
         const amount =
@@ -678,7 +739,8 @@ const NewInvoicePage: React.FC<NewInvoiceProps> = ({
                 item.price,
               )
             : toNumber(item.discountedPrice);
-        acc[key] = (acc[key] ?? 0) + toNumber(amount);
+        const safeAmount = Number.isFinite(amount) ? amount : 0;
+        acc[key] = (acc[key] ?? 0) + safeAmount;
         return acc;
       },
       {} as Record<string, number>,
@@ -687,26 +749,31 @@ const NewInvoicePage: React.FC<NewInvoiceProps> = ({
     const grossRounded = Object.values(sectionSums).reduce((sumRupees, s) => {
       return sumRupees + Math.round(toNumber(s));
     }, 0);
-    const total = grossRounded - toNumber(watchedExtraDiscount ?? 0);
-
-    form.setValue('totalAmount', total, {
-      shouldValidate: false,
-      shouldDirty: true,
-    });
+    return grossRounded - toNumber(watchedExtraDiscount ?? 0);
   }, [
     cumulativeDiscount,
     enableCumulativeDiscount,
-    form,
     hasActiveInvoiceItem,
     watchedExtraDiscount,
-    watchedInvoiceItems,
+    normalizedInvoiceItems,
     rowSectionMap,
   ]);
 
+  // sync computed total to form field for validation/submission; this does NOT trigger a
+  // re-render via useWatch because we removed the watchedTotalAmount subscription.
+  const prevTotalRef = useRef<number>(0);
+  useEffect(() => {
+    if (computedTotalAmount === prevTotalRef.current) return;
+    prevTotalRef.current = computedTotalAmount;
+    form.setValue('totalAmount', computedTotalAmount, {
+      shouldValidate: false,
+      shouldDirty: true,
+    });
+  }, [computedTotalAmount, form]);
+
   const getSelectedItem = useCallback(
-    (fieldValue: number) =>
-      inventory?.find((item) => item.id === toNumber(fieldValue)),
-    [inventory],
+    (fieldValue: number) => inventoryById.get(toNumber(fieldValue)),
+    [inventoryById],
   );
   const onItemSelectionChange = useCallback(
     async (rowIndex: number, val: string, onChange: Function) => {
@@ -820,9 +887,19 @@ const NewInvoicePage: React.FC<NewInvoiceProps> = ({
     [form, invoiceType, recalculateAutoDiscounts],
   );
 
+  // focus intent: set before append, consumed by useLayoutEffect AFTER React mounts new row
+  const pendingItemFocusRef = useRef<number | null>(null);
+  // scroll virtualized table to newly added row so it mounts before focus
+  const [virtualScrollToIndex, setVirtualScrollToIndex] = useState<
+    number | null
+  >(null);
+
   const handleAddNewRow = useCallback(() => {
     const entry = getInitialEntry();
+    const newRowIndex = fields.length;
     append({ ...entry });
+    pendingItemFocusRef.current = newRowIndex;
+    setVirtualScrollToIndex(newRowIndex);
     if (
       invoiceType === InvoiceType.Sale &&
       !useSingleAccount &&
@@ -836,17 +913,28 @@ const NewInvoicePage: React.FC<NewInvoiceProps> = ({
   }, [
     activeSectionId,
     append,
+    fields.length,
     getInitialEntry,
     invoiceType,
     setRowSectionMap,
     useSingleAccount,
   ]);
 
+  // after React commits new row to DOM, schedule focus on its item field
+  useLayoutEffect(() => {
+    const rowIndex = pendingItemFocusRef.current;
+    if (rowIndex == null) return;
+    pendingItemFocusRef.current = null;
+    scheduleItemFieldFocusAfterNewRow(form, rowIndex);
+    // clear scroll-to so it doesn't re-trigger on unrelated re-renders
+    setVirtualScrollToIndex(null);
+  }, [fields.length, form]);
+
   const onQuantityEnterAddRow = useCallback(
     (rowIndex: number) => {
       const qPath = `invoiceItems.${rowIndex}.quantity` as Path<Invoice>;
       const qty = toNumber(form.getValues(qPath));
-      form.setValue(qPath, qty, { shouldValidate: true, shouldDirty: true });
+      form.setValue(qPath, qty, { shouldDirty: true });
       form.setValue(
         `invoiceItems.${rowIndex}.discountedPrice` as Path<Invoice>,
         computeInvoiceItemTotal(
@@ -862,11 +950,9 @@ const NewInvoicePage: React.FC<NewInvoiceProps> = ({
         ),
         { shouldValidate: false, shouldDirty: true },
       );
-      const newRowIndex = fields.length;
       handleAddNewRow();
-      scheduleItemFieldFocusAfterNewRow(form, newRowIndex);
     },
-    [fields.length, form, handleAddNewRow],
+    [form, handleAddNewRow],
   );
 
   useCmdOrCtrlNShortcut(handleAddNewRow);
@@ -875,6 +961,7 @@ const NewInvoicePage: React.FC<NewInvoiceProps> = ({
     () => ({
       form: { control: form.control, getValues: form.getValues },
       inventory,
+      selectedInventoryCounts,
       invoiceType,
       resolvedRowLabels,
       resolvedRowCodes,
@@ -902,6 +989,7 @@ const NewInvoicePage: React.FC<NewInvoiceProps> = ({
       form.control,
       form.getValues,
       inventory,
+      selectedInventoryCounts,
       invoiceType,
       resolvedRowLabels,
       resolvedRowCodes,
@@ -928,6 +1016,30 @@ const NewInvoicePage: React.FC<NewInvoiceProps> = ({
   );
   const columns = useNewInvoiceColumns(columnsParams);
 
+  const getFieldRowKey = useCallback(
+    (row: unknown) => toString(get(row, 'fieldKey')),
+    [],
+  );
+
+  // Memoize DataTable element so React skips its entire reconciliation subtree
+  // when the page re-renders due to watchedInvoiceItems/total changes.
+  // During typing: columns (stable), fields (stable from useFieldArray),
+  // virtualScrollToIndex (null) are unchanged → memo reused → zero DataTable cost.
+  const lineItemTableElement = useMemo(
+    () => (
+      <DataTable
+        columns={columns}
+        data={fields}
+        getRowKey={getFieldRowKey}
+        sortingFns={defaultSortingFunctions}
+        compact
+        virtual
+        virtualScrollToIndex={virtualScrollToIndex}
+      />
+    ),
+    [columns, fields, getFieldRowKey, virtualScrollToIndex],
+  );
+
   const submitDisabledReason = useMemo((): string | undefined => {
     if (form.formState.isSubmitting) {
       return 'Saving invoice...';
@@ -941,18 +1053,10 @@ const NewInvoicePage: React.FC<NewInvoiceProps> = ({
       return `Select a ${partyLabel}`;
     }
 
-    const total = watchedTotalAmount;
-    if (
-      invoiceType === InvoiceType.Sale &&
-      (typeof total !== 'number' || total <= 0)
-    ) {
+    if (invoiceType === InvoiceType.Sale && computedTotalAmount <= 0) {
       return 'Invoice total must be greater than 0';
     }
-    if (
-      invoiceType === InvoiceType.Purchase &&
-      typeof total === 'number' &&
-      total < 0
-    ) {
+    if (invoiceType === InvoiceType.Purchase && computedTotalAmount < 0) {
       return 'Invoice total must not be negative';
     }
 
@@ -978,6 +1082,7 @@ const NewInvoicePage: React.FC<NewInvoiceProps> = ({
     }
     return undefined;
   }, [
+    computedTotalAmount,
     form,
     invoiceType,
     useSingleAccount,
@@ -985,7 +1090,6 @@ const NewInvoicePage: React.FC<NewInvoiceProps> = ({
     resolutionFallbacks.length,
     watchedMultipleAccountIds,
     watchedSingleAccountId,
-    watchedTotalAmount,
   ]);
 
   const postedNextNumberBlocked = useMemo(
@@ -1015,29 +1119,10 @@ const NewInvoicePage: React.FC<NewInvoiceProps> = ({
           ),
         }));
 
-      form.setValue('invoiceItems', updatedInvoiceItems, {
-        shouldValidate: false,
-        shouldDirty: true,
-      });
+      replace(updatedInvoiceItems);
     },
-    [form, isDiscountEditEnabled, setCumulativeDiscount],
+    [form, isDiscountEditEnabled, replace, setCumulativeDiscount],
   );
-
-  const tableInfoData = useNewInvoiceTableInfo({
-    control: form.control,
-    invoiceType,
-    watchedExtraDiscount,
-    watchedTotalAmount,
-    extraDiscountAccountOptions,
-    discountAccountExists,
-    enableCumulativeDiscount,
-    setEnableCumulativeDiscount,
-    cumulativeDiscount,
-    isDiscountEditEnabled,
-    onCumulativeDiscountChange,
-    useSingleAccount,
-    splitByItemType,
-  });
 
   const submitInvoice = async (
     values: z.infer<typeof formSchema>,
@@ -1142,9 +1227,6 @@ const NewInvoicePage: React.FC<NewInvoiceProps> = ({
   });
 
   const onSubmit = async (values: z.infer<typeof formSchema>) => {
-    // eslint-disable-next-line no-console
-    console.log('onSubmit invoice:', values);
-
     if (
       isSplitTypedAccountResolutionSubmitBlocked({
         invoiceType,
@@ -1648,9 +1730,7 @@ const NewInvoicePage: React.FC<NewInvoiceProps> = ({
         {!showAddInvoiceNumberGate && showInvoiceForm ? (
           <Form {...form}>
             <form
-              onSubmit={form.handleSubmit(onSubmit, (errors) =>
-                console.log('onSubmit errors', errors),
-              )}
+              onSubmit={form.handleSubmit(onSubmit, () => undefined)}
               onReset={() => {
                 form.reset(defaultFormValues);
                 setIsDateExplicitlySet(false);
@@ -1997,19 +2077,170 @@ const NewInvoicePage: React.FC<NewInvoiceProps> = ({
                       )}
                     </div>
                   )}
-                <DataTable
-                  columns={columns}
-                  data={fields}
-                  sortingFns={defaultSortingFunctions}
-                  infoData={tableInfoData}
-                  compact
-                />
+                {lineItemTableElement}
                 {form.formState.errors.invoiceItems && (
                   <p className="text-sm font-medium text-destructive">
                     {get(form.formState.errors.invoiceItems, 'message', null)}
                   </p>
                 )}
               </div>
+
+              {/* Invoice summary — always visible while scrolling line items */}
+              {isSale && (
+                <section
+                  className="sticky bottom-0 z-10 mt-4 border-t bg-background/95 backdrop-blur-sm px-3 py-2 space-y-1.5"
+                  aria-label="Invoice summary"
+                >
+                  {isDiscountEditEnabled && (
+                    <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+                      <span className="w-44 shrink-0 text-xs font-medium text-muted-foreground">
+                        Cumulative Discount (%)
+                      </span>
+                      <div className="flex items-center gap-2">
+                        <Checkbox
+                          checked={enableCumulativeDiscount}
+                          onCheckedChange={(checked) =>
+                            setEnableCumulativeDiscount(checked === true)
+                          }
+                        />
+                        <span className="text-xs">Enable</span>
+                      </div>
+                      <Input
+                        value={cumulativeDiscount}
+                        type="number"
+                        step="any"
+                        min={0}
+                        max={100}
+                        disabled={!enableCumulativeDiscount}
+                        onChange={(e) =>
+                          onCumulativeDiscountChange(e.target.value)
+                        }
+                        className="h-7 w-24 text-sm"
+                      />
+                    </div>
+                  )}
+                  <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+                    <span className="w-44 shrink-0 text-xs font-medium text-muted-foreground">
+                      Extra discount ({currencyFormatOptions.currency})
+                    </span>
+                    <FormField
+                      control={form.control}
+                      name="extraDiscount"
+                      render={({ field }) => (
+                        <FormItem className="min-w-0 flex-1 max-w-[200px] space-y-0">
+                          <FormControl>
+                            <Input
+                              {...field}
+                              className="h-7 text-sm"
+                              type="number"
+                              step="any"
+                              min={0}
+                              onBlur={(e) =>
+                                field.onChange(toNumber(e.target.value))
+                              }
+                              onChange={(e) =>
+                                field.onChange(toNumber(e.target.value))
+                              }
+                            />
+                          </FormControl>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+                  </div>
+                  {toNumber(watchedExtraDiscount) > 0 && splitByItemType && (
+                    <div className="flex flex-wrap items-start gap-x-3 gap-y-1">
+                      <span className="w-44 shrink-0 pt-1.5 text-xs font-medium text-muted-foreground">
+                        Extra discount from account
+                      </span>
+                      <FormField
+                        control={form.control}
+                        name="extraDiscountAccountId"
+                        render={({ field }) => (
+                          <FormItem className="min-w-[280px] flex-1 max-w-md space-y-0">
+                            <FormControl>
+                              <VirtualSelect<{
+                                id: number;
+                                name: string;
+                                code?: string;
+                              }>
+                                options={extraDiscountAccountOptions}
+                                value={field.value ?? null}
+                                onChange={(val) =>
+                                  field.onChange(
+                                    val ? toNumber(val) : undefined,
+                                  )
+                                }
+                                placeholder="Select account"
+                                searchPlaceholder="Search accounts..."
+                                disabled={
+                                  extraDiscountAccountOptions.length === 0
+                                }
+                                renderTriggerValue={({
+                                  selected,
+                                  placeholder,
+                                }) =>
+                                  selected ? (
+                                    <span className="flex w-full min-w-0 items-center justify-between gap-2 px-3 py-2 text-sm">
+                                      <span className="min-w-0 truncate">
+                                        {selected.name}
+                                      </span>
+                                      {selected.code ? (
+                                        <span className="shrink-0 text-xs font-mono text-muted-foreground">
+                                          {selected.code}
+                                        </span>
+                                      ) : null}
+                                    </span>
+                                  ) : (
+                                    <span className="px-3 text-muted-foreground">
+                                      {placeholder}
+                                    </span>
+                                  )
+                                }
+                                renderSelectItem={(item) => (
+                                  <div className="flex min-w-[220px] items-center justify-between gap-2">
+                                    <span className="min-w-0 truncate text-sm">
+                                      {item.name}
+                                    </span>
+                                    {item.code ? (
+                                      <span className="shrink-0 text-xs font-mono text-muted-foreground">
+                                        {item.code}
+                                      </span>
+                                    ) : null}
+                                  </div>
+                                )}
+                              />
+                            </FormControl>
+                            {discountAccountExists === false && (
+                              <p className="text-sm text-destructive mt-1">
+                                Create a &quot;{DISCOUNT_ACCOUNT_NAME}&quot;
+                                expense account to use extra discount.
+                              </p>
+                            )}
+                            <FormMessage />
+                          </FormItem>
+                        )}
+                      />
+                    </div>
+                  )}
+                  <div className="flex items-center gap-x-3 pt-1 border-t border-border/60">
+                    <span className="w-44 shrink-0 text-sm font-semibold text-primary">
+                      Total
+                    </span>
+                    <p
+                      className={cn(
+                        'text-sm font-semibold tabular-nums',
+                        typeof computedTotalAmount === 'number' &&
+                          'border border-primary rounded-md px-2 py-0.5',
+                      )}
+                    >
+                      {typeof computedTotalAmount === 'number'
+                        ? getFormattedCurrency(computedTotalAmount)
+                        : null}
+                    </p>
+                  </div>
+                </section>
+              )}
 
               <div className="flex justify-between gap-6 pb-6">
                 <Tooltip>

--- a/src/renderer/views/NewInvoice/index.tsx
+++ b/src/renderer/views/NewInvoice/index.tsx
@@ -327,6 +327,10 @@ const NewInvoicePage: React.FC<NewInvoiceProps> = ({
   const totalDebounceRef = useRef<ReturnType<typeof setTimeout>>();
   const suppressWatchRef = useRef(false);
 
+  // live snapshot of invoiceItems — updated by every form.watch callback.
+  // used by handleRemoveRow to bypass form.getValues (stale after structural ops).
+  const liveItemsRef = useRef<Record<string, unknown>[]>([]);
+
   const recomputeDerivedState = useCallback(
     (immediate = false) => {
       const raw = form.getValues('invoiceItems');
@@ -338,6 +342,8 @@ const NewInvoicePage: React.FC<NewInvoiceProps> = ({
         discount?: number;
         discountedPrice?: number;
       }>;
+
+      liveItemsRef.current = items;
 
       const newKey = items.map((i) => toNumber(i?.inventoryId)).join(',');
       setItemStructureKey((prev) => (prev === newKey ? prev : newKey));
@@ -796,17 +802,15 @@ const NewInvoicePage: React.FC<NewInvoiceProps> = ({
       const removedRow = fields[rowIndex];
       const removedId = toNumber(get(removedRow, 'id'));
 
-      // Use replace() instead of remove(). RHF's remove() updates _fields
-      // before _formValues, and virtualized (non-mounted) FormFields don't
-      // re-register after index shifts — leaving _formValues permanently stale.
-      // replace() writes the full array atomically, bypassing both issues.
+      // Use replace() instead of remove() — see AGENTS.md "RHF + Virtualization Rules".
+      // Read from liveItemsRef (kept current by form.watch callback) instead of
+      // form.getValues('invoiceItems') which returns stale _formValues after structural ops.
       suppressWatchRef.current = true;
-      const kept = [];
-      for (let i = 0; i < fields.length; i += 1) {
-        if (i !== rowIndex) kept.push(form.getValues(`invoiceItems.${i}`));
-      }
-      form.clearErrors(`invoiceItems.${rowIndex}` as const);
-      replace(kept);
+      const kept = liveItemsRef.current.filter((_, i) => i !== rowIndex);
+      // clear entire invoiceItems error tree — array-level .refine() errors
+      // (e.g. "Each item can only be added once") live on 'invoiceItems', not indices
+      form.clearErrors('invoiceItems');
+      replace(kept as typeof fields);
       suppressWatchRef.current = false;
 
       requestAnimationFrame(() => recomputeDerivedState(true));
@@ -1293,6 +1297,17 @@ const NewInvoicePage: React.FC<NewInvoiceProps> = ({
     formSchema,
   });
 
+  // shown when form.handleSubmit validation fails — prevents silent "nothing happens" on Save.
+  // schema's .superRefine sets per-row errors (highlighted in table) AND a root-level message with item names (shown here as toast).
+  const onValidationError = useCallback((errors: Record<string, unknown>) => {
+    const itemsMsg = get(errors, 'invoiceItems.message');
+    const rootMsg = get(errors, 'invoiceItems.root.message');
+    const msg = itemsMsg ?? rootMsg;
+    if (typeof msg === 'string' && msg.length > 0) {
+      toast({ variant: 'destructive', description: msg, duration: 8000 });
+    }
+  }, []);
+
   const onSubmit = async (values: z.infer<typeof formSchema>) => {
     if (
       isSplitTypedAccountResolutionSubmitBlocked({
@@ -1644,7 +1659,7 @@ const NewInvoicePage: React.FC<NewInvoiceProps> = ({
         onUseCurrentDate={() => {
           form.setValue('date', toLocalNoonIsoString(new Date()));
           dateConfirmedInModalRef.current = true;
-          form.handleSubmit(onSubmit)();
+          form.handleSubmit(onSubmit, onValidationError)();
         }}
       />
 
@@ -1797,7 +1812,7 @@ const NewInvoicePage: React.FC<NewInvoiceProps> = ({
         {!showAddInvoiceNumberGate && showInvoiceForm ? (
           <Form {...form}>
             <form
-              onSubmit={form.handleSubmit(onSubmit, () => undefined)}
+              onSubmit={form.handleSubmit(onSubmit, onValidationError)}
               onReset={() => {
                 form.reset(defaultFormValues);
                 setIsDateExplicitlySet(false);
@@ -2380,7 +2395,7 @@ const NewInvoicePage: React.FC<NewInvoiceProps> = ({
                       }
                       onClick={() => {
                         submitSaveKindRef.current = 'invoice';
-                        form.handleSubmit(onSubmit)();
+                        form.handleSubmit(onSubmit, onValidationError)();
                       }}
                     >
                       {primarySubmitLabel}
@@ -2399,7 +2414,7 @@ const NewInvoicePage: React.FC<NewInvoiceProps> = ({
                       className="min-h-[44px]"
                       onClick={() => {
                         submitSaveKindRef.current = 'quotation';
-                        form.handleSubmit(onSubmit)();
+                        form.handleSubmit(onSubmit, onValidationError)();
                       }}
                     >
                       Save as quotation
@@ -2415,7 +2430,7 @@ const NewInvoicePage: React.FC<NewInvoiceProps> = ({
                       onClick={() => {
                         submitSaveKindRef.current = 'invoice';
                         openPrintAfterSaveRef.current = true;
-                        form.handleSubmit(onSubmit)();
+                        form.handleSubmit(onSubmit, onValidationError)();
                       }}
                     >
                       <Printer size={16} className="mr-2" />

--- a/src/renderer/views/NewInvoice/lib/invoiceFormFocus.ts
+++ b/src/renderer/views/NewInvoice/lib/invoiceFormFocus.ts
@@ -1,6 +1,19 @@
 import type { FieldValues, UseFormReturn } from 'react-hook-form';
 
-/** low-end machines and virtual rows can need several retries before the target field is mounted and stable */
+/**
+ * Focus scheduling for the new-invoice line-item grid.
+ *
+ * WHY retries: after append(), React re-renders asynchronously and the new row's
+ * VirtualSelect trigger may not be in the DOM yet. Retries cover the mounting window.
+ *
+ * WHY DOM fallback (scheduleItemFieldFocusAfterNewRow): form.setFocus relies on RHF's
+ * _fields registry. With virtualization, non-visible FormFields aren't mounted, so
+ * setFocus often can't find the ref. The DOM query finds the input directly.
+ *
+ * WHY focus guard (re-acquire disconnected element): post-append re-renders can unmount
+ * and remount the VirtualSelect trigger input. The guard detects when the focused element
+ * is disconnected and re-queries the DOM for the replacement.
+ */
 const FOCUS_RETRY_DELAYS_MS = [0, 80, 200, 400, 650] as const;
 
 type SetFocusPath<T extends FieldValues> = Parameters<

--- a/src/renderer/views/NewInvoice/lib/invoiceFormFocus.ts
+++ b/src/renderer/views/NewInvoice/lib/invoiceFormFocus.ts
@@ -1,13 +1,48 @@
 import type { FieldValues, UseFormReturn } from 'react-hook-form';
 
-/** second pass: radix + item cell re-render can steal focus after one rAF */
-const QUANTITY_FOCUS_RETRY_MS = 150;
-
-const ITEM_FIELD_FOCUS_RETRY_MS = 150;
+/** low-end machines and virtual rows can need several retries before the target field is mounted and stable */
+const FOCUS_RETRY_DELAYS_MS = [0, 80, 200, 400, 650] as const;
 
 type SetFocusPath<T extends FieldValues> = Parameters<
   UseFormReturn<T>['setFocus']
 >[0];
+
+/**
+ * Attempt focus with retries; stop as soon as activeElement changes (focus landed).
+ * Only the first successful attempt uses `shouldSelect` — retries never re-select text
+ * so fast typing after focus is not disrupted.
+ */
+function scheduleFocusWithRetries<T extends FieldValues>(
+  form: UseFormReturn<T>,
+  path: SetFocusPath<T>,
+  shouldSelectOnFirst: boolean,
+): void {
+  let done = false;
+
+  const tryFocus = (select: boolean) => {
+    if (done) return;
+    const before = document.activeElement;
+    form.setFocus(path, select ? { shouldSelect: true } : undefined);
+    // activeElement changed → focus succeeded
+    if (document.activeElement !== before) {
+      done = true;
+    }
+  };
+
+  FOCUS_RETRY_DELAYS_MS.forEach((delay) => {
+    const isFirst = delay === 0;
+    const run = () => tryFocus(isFirst && shouldSelectOnFirst);
+    if (isFirst) {
+      queueMicrotask(() => {
+        requestAnimationFrame(() => {
+          requestAnimationFrame(run);
+        });
+      });
+      return;
+    }
+    window.setTimeout(run, delay);
+  });
+}
 
 /** focus quantity after picking a line item (VirtualSelect suppresses radix refocus; timing is still flaky with one frame) */
 export function scheduleQuantityFocusAfterItemSelect<T extends FieldValues>(
@@ -15,34 +50,119 @@ export function scheduleQuantityFocusAfterItemSelect<T extends FieldValues>(
   rowIndex: number,
 ): void {
   const path = `invoiceItems.${rowIndex}.quantity` as SetFocusPath<T>;
-  const run = () => {
-    form.setFocus(path, { shouldSelect: true });
-  };
-  requestAnimationFrame(run);
-  window.setTimeout(run, QUANTITY_FOCUS_RETRY_MS);
+  scheduleFocusWithRetries(form, path, true);
 }
 
-/** focus item VirtualSelect on a new row after append (field ref on trigger; timing matches quantity focus) */
+/**
+ * Focus item VirtualSelect on a new row after append.
+ *
+ * `form.setFocus` often fails for VirtualSelect fields because the trigger element is
+ * registered through `triggerRef={field.ref}` (not native `{...field}`), which RHF may
+ * not wire into `_fields` the same way.  We try `setFocus` first then fall back to a
+ * direct DOM query for the trigger input in the target row.
+ */
 export function scheduleItemFieldFocusAfterNewRow<T extends FieldValues>(
   form: UseFormReturn<T>,
   rowIndex: number,
 ): void {
   const path = `invoiceItems.${rowIndex}.inventoryId` as SetFocusPath<T>;
-  const run = () => {
-    form.setFocus(path, { shouldSelect: true });
+  let done = false;
+  let target: HTMLElement | null = null;
+
+  /** find the item-selector input for this row — works in both virtual and non-virtual tables */
+  const findItemInput = (): HTMLInputElement | null => {
+    // virtual mode: react-virtuoso sets data-index on each <tr>
+    const row =
+      document.querySelector(`tr[data-index="${rowIndex}"]`) ??
+      // non-virtual fallback: sequential row position
+      document.querySelectorAll('table tbody > tr')[rowIndex];
+    if (!row) return null;
+    return row.querySelector(
+      'input[autocomplete="off"]:not([type="number"]):not([type="hidden"])',
+    );
   };
-  requestAnimationFrame(run);
-  window.setTimeout(run, ITEM_FIELD_FOCUS_RETRY_MS);
+
+  const tryFocus = () => {
+    if (done) return;
+
+    // 1. Try RHF setFocus
+    const before = document.activeElement;
+    form.setFocus(path);
+    if (document.activeElement !== before) {
+      target = document.activeElement as HTMLElement;
+    }
+
+    // 2. Fallback: DOM query
+    if (!target) {
+      const input = findItemInput();
+      if (input) {
+        input.focus();
+        if (document.activeElement === input) {
+          target = input;
+        }
+      }
+    }
+
+    if (!target) return;
+    done = true;
+  };
+
+  // Re-renders after append unmount+remount VirtualSelect trigger input.
+  // Guard re-acquires the replacement element and re-applies focus.
+  const guardUntil = Date.now() + 1500;
+  const guard = () => {
+    if (Date.now() > guardUntil) return;
+    if (target && !target.isConnected) {
+      // element was replaced by re-render — find new one
+      const fresh = findItemInput();
+      if (fresh) {
+        fresh.focus();
+        target = fresh;
+      }
+      return;
+    }
+    if (target && document.activeElement !== target) {
+      target.focus();
+    }
+  };
+
+  // Initial focus attempts via retries
+  FOCUS_RETRY_DELAYS_MS.forEach((delay) => {
+    const isFirst = delay === 0;
+    const run = () => {
+      tryFocus();
+      guard();
+    };
+    if (isFirst) {
+      queueMicrotask(() => {
+        requestAnimationFrame(() => {
+          requestAnimationFrame(run);
+        });
+      });
+      return;
+    }
+    window.setTimeout(run, delay);
+  });
+
+  // Extended guard: re-renders can disconnect element well after initial focus
+  window.setTimeout(guard, 800);
+  window.setTimeout(guard, 1200);
 }
 
 /** focus date after party/section customer pick; no shouldSelect — trigger is a button */
 export function scheduleDateFieldFocusAfterPartySelect<T extends FieldValues>(
   form: UseFormReturn<T>,
 ): void {
+  let done = false;
   queueMicrotask(() => {
     requestAnimationFrame(() => {
       requestAnimationFrame(() => {
+        if (done) return;
+        const before = document.activeElement;
         form.setFocus('date' as SetFocusPath<T>);
+        if (document.activeElement !== before) {
+          done = true;
+        }
       });
     });
   });

--- a/src/renderer/views/NewInvoice/schema.ts
+++ b/src/renderer/views/NewInvoice/schema.ts
@@ -110,16 +110,50 @@ export const buildNewInvoiceFormSchema = (
             }),
           )
           .min(1, 'Add at-least one invoice item')
-          // validate each item can only be added once
-          .refine(
-            (items) => {
-              const ids = items
-                .map((i) => i.inventoryId)
-                .filter((id) => id > 0);
-              return new Set(ids).size === ids.length;
-            },
-            { message: 'Each item can only be added once' },
-          )
+          // validate each item can only be added once — sets per-row errors
+          // so the duplicate rows are highlighted in the table, AND a root-level message for the validation toast with item names
+          .superRefine((items, ctx) => {
+            const seen = new Map<number, number[]>();
+            items.forEach((item, idx) => {
+              if (item.inventoryId <= 0) return;
+              const indices = seen.get(item.inventoryId) ?? [];
+              indices.push(idx);
+              seen.set(item.inventoryId, indices);
+            });
+            const dupes = [...seen.entries()].filter(
+              ([, indices]) => indices.length > 1,
+            );
+            if (dupes.length === 0) return;
+
+            const invById = new Map(
+              (inventory ?? []).map((inv) => [inv.id, inv]),
+            );
+            dupes.forEach(([inventoryId, indices]) => {
+              const name =
+                invById.get(inventoryId)?.name ?? `Item #${inventoryId}`;
+              indices.forEach((idx) => {
+                const otherRows = indices
+                  .filter((i) => i !== idx)
+                  .map((i) => i + 1)
+                  .join(', ');
+                ctx.addIssue({
+                  code: z.ZodIssueCode.custom,
+                  message: `"${name}" already in row ${otherRows}`,
+                  path: [idx, 'inventoryId'],
+                });
+              });
+            });
+
+            const summaries = dupes.map(([id, indices]) => {
+              const name = invById.get(id)?.name ?? `#${id}`;
+              const rows = indices.map((i) => i + 1).join(', ');
+              return `${name} (rows ${rows})`;
+            });
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              message: `Duplicate items: ${summaries.join('; ')}`,
+            });
+          })
           // sale only: cannot invoice more than current stock; purchase has no on-hand cap
           .superRefine((items, ctx) => {
             if (invoiceType !== InvoiceType.Sale) return;


### PR DESCRIPTION
> [!NOTE] 
> Next problem to solve: "React re-renders unmount the target element after append()" by "stop the re-render cascade by removing useWatch('invoiceItems')"

## Describe your changes

- Refactored useNewInvoiceInventory hook to cache inventory data for performance
- Updated useNewInvoiceResolution to track changes in resolved accounts and notify on changes
- Modified useNewInvoiceSections to streamline section management based on line item IDs
- Enhanced useNewInvoiceTableInfo to support additional account properties and row number column
- Improved NewInvoicePage to optimize form handling and total amount calculation
- Added focus management utilities for better user experience during item selection and row addition
- Introduced invoice summary section for cumulative and extra discounts visibility

### Proof [Optional]

Progress across all iterations at 4x slowdown:

| Metric | Before fixes | + Virtualization | + DataTable memo | No slowdown |
|-----------|--------------|------------------|------------------|-------------|
| Scripting | ~9000ms      | 4400ms           | 4798ms           | 2190ms      |
| Rendering | ~3000ms      | 880ms            | 398ms            | 96ms        |
| Blocking  | ~2461ms      | 2458ms           | 1887ms           | 185ms       |
| Total     | ~20s         | 9.1s             | 9.2s             | 7.3s        |

## Issue ticket number and link

Closes #

## Checklist before requesting a review

- [x] I have bumped version in package.json files.
- [ ] I have confirmed that it works on Mac and Windows.
- [ ] I have added tests.
