### PR TITLE
Compact layout all around the app

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "easy-accounting",
-  "version": "0.1.39",
+  "version": "0.1.40",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.1.39",
+      "version": "0.1.40",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.39",
+  "version": "0.1.40",
   "description": "Easy Accounting is a simple accounting software for SMEs.",
   "keywords": [
     "easyAccounting",

--- a/release/app/package-lock.json
+++ b/release/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "easy-accounting",
-  "version": "0.1.39",
+  "version": "0.1.40",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "easy-accounting",
-      "version": "0.1.39",
+      "version": "0.1.40",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/release/app/package.json
+++ b/release/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "easy-accounting",
-  "version": "0.1.39",
+  "version": "0.1.40",
   "description": "Easy Accounting",
   "license": "MIT",
   "author": {

--- a/src/renderer/components/ledger/LedgerTableBase.tsx
+++ b/src/renderer/components/ledger/LedgerTableBase.tsx
@@ -131,6 +131,7 @@ export const LedgerTableBase: React.FC<LedgerTableBaseProps> = ({
         sortingFns={defaultSortingFunctions}
         enableSorting={false}
         compact
+        virtualHeightMode="fill"
         stickyFooterRow={stickyFooterRow}
       />
     </div>

--- a/src/renderer/shad/ui/dataTable.tsx
+++ b/src/renderer/shad/ui/dataTable.tsx
@@ -19,16 +19,16 @@ import {
   TableHeader,
   TableRow,
 } from 'renderer/shad/ui/table';
-import { get, toString, debounce } from 'lodash';
+import { clamp, debounce, get, toString } from 'lodash';
 import { cn } from '@/renderer/lib/utils';
 import {
   forwardRef,
   useCallback,
-  useEffect,
   useLayoutEffect,
   useRef,
   useMemo,
   useState,
+  useSyncExternalStore,
 } from 'react';
 import { TableVirtuoso, type TableVirtuosoHandle } from 'react-virtuoso';
 import { HelpCircle } from 'lucide-react';
@@ -60,6 +60,12 @@ interface DataTableProps<TData, TValue> extends Partial<TableOptions<TData>> {
   /** tighter row/header/cell padding for dense grids */
   compact?: boolean;
   /**
+   * controls how virtual table height is computed
+   * - content: shrink-to-rows (best for editors/forms; reduces wasted space)
+   * - fill: grow to available viewport space (best for reports/list screens)
+   */
+  virtualHeightMode?: 'content' | 'fill';
+  /**
    * one cell per visible column; widths match tanstack column sizes.
    * stays aligned with virtual + non-virtual tables; hidden when printing.
    */
@@ -77,6 +83,13 @@ interface DataTableProps<TData, TValue> extends Partial<TableOptions<TData>> {
    */
   onViewModelChange?: (rows: TData[]) => void;
 }
+
+const subscribeWindowInnerHeight = (cb: () => void) => {
+  window.addEventListener('resize', cb);
+  return () => window.removeEventListener('resize', cb);
+};
+
+const getWindowInnerHeightSnapshot = () => window.innerHeight;
 
 const TableComponent = forwardRef<
   HTMLTableElement,
@@ -218,6 +231,7 @@ const DataTable = <TData, TValue>({
   infoData,
   virtual = false,
   compact = false,
+  virtualHeightMode = 'content',
   stickyFooterRow,
   virtualScrollToIndex = null,
   searchPlaceholder,
@@ -241,47 +255,14 @@ const DataTable = <TData, TValue>({
   });
   const [searchValue, setSearchValue] = useState('');
   const [searchInputValue, setSearchInputValue] = useState('');
-  const [height, setHeight] = useState(0);
   const containerRef = useRef<HTMLDivElement>(null);
   const isSearchHydratedRef = useRef(false);
 
-  // when virtual toggles on, seed height so virtuoso is usable before layout measure runs
-  useEffect(() => {
-    if (!virtual) return;
-    setHeight((h) => (h > 0 ? h : 480));
-  }, [virtual]);
-
-  // calculate height of the table based for virtual table
-  useEffect(() => {
-    const calculateHeight = () => {
-      if (!containerRef.current || !virtual) return;
-
-      const container = containerRef.current;
-      const rect = container.getBoundingClientRect();
-      const searchBarHeight =
-        container.querySelector('.search-container')?.getBoundingClientRect()
-          .height || 0;
-
-      // calculate available space from the container's top to the viewport bottom
-      // subtract search bar height and some padding to prevent scrollbar from appearing
-      const availableHeight =
-        window.innerHeight - rect.top - searchBarHeight - 50;
-
-      // ensure minimum height of 400px and maximum of available space
-      const newHeight = Math.max(
-        400,
-        Math.min(availableHeight, window.innerHeight - 100),
-      );
-
-      setHeight(newHeight);
-    };
-
-    calculateHeight();
-    // recalculate on window resize
-    window.addEventListener('resize', calculateHeight);
-
-    return () => window.removeEventListener('resize', calculateHeight);
-  }, [virtual]);
+  const windowInnerHeight = useSyncExternalStore(
+    subscribeWindowInnerHeight,
+    getWindowInnerHeightSnapshot,
+    () => 900,
+  );
 
   const filteredData = useMemo(() => {
     if (!searchValue || !searchFields?.length) {
@@ -305,7 +286,7 @@ const DataTable = <TData, TValue>({
       }, 300),
     [],
   );
-  useEffect(() => () => debounceSearch.cancel(), [debounceSearch]);
+  useLayoutEffect(() => () => debounceSearch.cancel(), [debounceSearch]);
 
   const handleSearchInputChange = (value: string) => {
     setSearchInputValue(value);
@@ -328,7 +309,7 @@ const DataTable = <TData, TValue>({
     isSearchHydratedRef.current = true;
   }, [searchPersistenceKey]);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (!searchPersistenceKey) return;
     if (!isSearchHydratedRef.current) return;
     window.electron.store.set(searchPersistenceKey, searchInputValue);
@@ -372,7 +353,7 @@ const DataTable = <TData, TValue>({
     );
   }, [filteredData, sorting, searchValue]);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (!virtual) return;
     if (virtualScrollToIndex == null || virtualScrollToIndex < 0) return;
     requestAnimationFrame(() => {
@@ -396,6 +377,47 @@ const DataTable = <TData, TValue>({
   const hasStickyFooter = Boolean(
     stickyFooterRow && stickyFooterRow.length > 0,
   );
+
+  const virtualTableHeight = useMemo(() => {
+    if (!virtual) return 0;
+
+    if (virtualHeightMode === 'fill') {
+      const container = containerRef.current;
+      const rectTop = container?.getBoundingClientRect().top ?? 0;
+      const searchBarHeight =
+        container?.querySelector('.search-container')?.getBoundingClientRect()
+          .height ?? 0;
+
+      // fill available space from table top to viewport bottom, minus search bar and padding.
+      const availablePx = windowInnerHeight - rectTop - searchBarHeight - 24;
+      const minPx = 240;
+      const maxPx = Math.max(320, windowInnerHeight - 120);
+      return clamp(availablePx, minPx, maxPx);
+    }
+
+    // compact grid: tighter row heights; estimate is only used to avoid large wasted space.
+    const headerRowPx = compact ? 28 : 32;
+    const bodyRowPx = compact ? 32 : 40;
+    const footerRowPx = hasStickyFooter ? bodyRowPx : 0;
+
+    // empty state needs breathing room for "No results" copy.
+    const emptyStatePx = rows.length ? 0 : 160;
+    const contentPx =
+      headerRowPx + footerRowPx + rows.length * bodyRowPx + emptyStatePx;
+
+    // keep table usable but avoid pushing totals/actions below fold on small invoices.
+    const minPx = 160;
+    const maxPx = Math.max(240, Math.floor(windowInnerHeight * 0.55));
+
+    return clamp(contentPx, minPx, maxPx);
+  }, [
+    compact,
+    hasStickyFooter,
+    rows.length,
+    virtual,
+    virtualHeightMode,
+    windowInnerHeight,
+  ]);
 
   const leafHeaders =
     table.getHeaderGroups()[0]?.headers.filter((h) => !h.isPlaceholder) ?? [];
@@ -529,7 +551,7 @@ const DataTable = <TData, TValue>({
                 <TableVirtuoso
                   ref={tableVirtuosoRef}
                   data={rows}
-                  style={{ height }}
+                  style={{ height: virtualTableHeight }}
                   computeItemKey={(_, row) => (row as Row<TData>).id}
                   components={{
                     Table: TableComponent,
@@ -561,7 +583,7 @@ const DataTable = <TData, TValue>({
           <TableVirtuoso
             ref={tableVirtuosoRef}
             data={rows}
-            style={{ height }}
+            style={{ height: virtualTableHeight }}
             computeItemKey={(_, row) => (row as Row<TData>).id}
             components={{
               Table: TableComponent,

--- a/src/renderer/shad/ui/dataTable.tsx
+++ b/src/renderer/shad/ui/dataTable.tsx
@@ -257,6 +257,10 @@ const DataTable = <TData, TValue>({
   const [searchInputValue, setSearchInputValue] = useState('');
   const containerRef = useRef<HTMLDivElement>(null);
   const isSearchHydratedRef = useRef(false);
+  const [fillMeasure, setFillMeasure] = useState<{
+    rectTop: number;
+    searchBarHeight: number;
+  } | null>(null);
 
   const windowInnerHeight = useSyncExternalStore(
     subscribeWindowInnerHeight,
@@ -378,18 +382,71 @@ const DataTable = <TData, TValue>({
     stickyFooterRow && stickyFooterRow.length > 0,
   );
 
+  const measureFill = useCallback(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const rectTop = container.getBoundingClientRect().top;
+    const searchBarHeight =
+      container.querySelector('.search-container')?.getBoundingClientRect()
+        .height ?? 0;
+
+    setFillMeasure((prev) => {
+      if (
+        prev &&
+        Math.abs(prev.rectTop - rectTop) < 0.5 &&
+        Math.abs(prev.searchBarHeight - searchBarHeight) < 0.5
+      ) {
+        return prev;
+      }
+      return { rectTop, searchBarHeight };
+    });
+  }, []);
+
+  useLayoutEffect(() => {
+    if (!virtual) return;
+    if (virtualHeightMode !== 'fill') return;
+
+    // run once after mount/layout, then again on next frame to catch late layout shifts
+    measureFill();
+    const raf = requestAnimationFrame(measureFill);
+
+    // keep the measurement fresh as the table moves (scrolling) or resizes (layout shifts)
+    window.addEventListener('scroll', measureFill, true);
+
+    let ro: ResizeObserver | null = null;
+    if (typeof ResizeObserver !== 'undefined') {
+      ro = new ResizeObserver(() => measureFill());
+      const container = containerRef.current;
+      if (container) {
+        ro.observe(container);
+        const searchEl = container.querySelector('.search-container');
+        if (searchEl) ro.observe(searchEl);
+      }
+    }
+
+    return () => {
+      cancelAnimationFrame(raf);
+      window.removeEventListener('scroll', measureFill, true);
+      ro?.disconnect();
+    };
+  }, [measureFill, virtual, virtualHeightMode, windowInnerHeight]);
+
   const virtualTableHeight = useMemo(() => {
     if (!virtual) return 0;
 
     if (virtualHeightMode === 'fill') {
-      const container = containerRef.current;
-      const rectTop = container?.getBoundingClientRect().top ?? 0;
-      const searchBarHeight =
-        container?.querySelector('.search-container')?.getBoundingClientRect()
-          .height ?? 0;
+      if (!fillMeasure) {
+        // avoid over-estimation before first layout measurement
+        return clamp(Math.floor(windowInnerHeight * 0.4), 240, 560);
+      }
 
       // fill available space from table top to viewport bottom, minus search bar and padding.
-      const availablePx = windowInnerHeight - rectTop - searchBarHeight - 24;
+      const availablePx =
+        windowInnerHeight -
+        fillMeasure.rectTop -
+        fillMeasure.searchBarHeight -
+        24;
       const minPx = 240;
       const maxPx = Math.max(320, windowInnerHeight - 120);
       return clamp(availablePx, minPx, maxPx);
@@ -412,6 +469,7 @@ const DataTable = <TData, TValue>({
     return clamp(contentPx, minPx, maxPx);
   }, [
     compact,
+    fillMeasure,
     hasStickyFooter,
     rows.length,
     virtual,

--- a/src/renderer/views/Accounts/index.tsx
+++ b/src/renderer/views/Accounts/index.tsx
@@ -573,6 +573,7 @@ const AccountsPage: React.FC<AccountPageProps> = ({
           defaultSortField="id"
           sortingFns={defaultSortingFunctions}
           virtual
+          virtualHeightMode={isMini ? 'content' : 'fill'}
           isMini={isMini}
           searchPlaceholder="Search accounts..."
           searchFields={[

--- a/src/renderer/views/Inventory/inventoryTable.tsx
+++ b/src/renderer/views/Inventory/inventoryTable.tsx
@@ -244,6 +244,7 @@ export const InventoryTable: React.FC<InventoryTableProps> = ({
           listPosition: listPositionSortingFn,
         }}
         virtual
+        virtualHeightMode="fill"
         compact
         defaultSortField="listPosition"
         searchPersistenceKey="datatable:inventory:search"

--- a/src/renderer/views/Invoices/index.tsx
+++ b/src/renderer/views/Invoices/index.tsx
@@ -475,6 +475,7 @@ const InvoicesPage: FC<InvoicesProps> = ({
             defaultSortField="invoiceNumber"
             defaultSortDirection="desc"
             virtual
+            virtualHeightMode={isMini ? 'content' : 'fill'}
             isMini={isMini}
             searchPlaceholder={`Search ${invoiceType.toLowerCase()} invoices...`}
             searchFields={[

--- a/src/renderer/views/Journals/index.tsx
+++ b/src/renderer/views/Journals/index.tsx
@@ -139,13 +139,13 @@ const JournalsPage: React.FC<HasMiniView> = ({
             },
             {
               accessorKey: 'discountPercentage',
-              header: 'Discount%',
+              header: 'Dis',
               cell: ({ row }) =>
                 row.original.discountPercentage
                   ? `${row.original.discountPercentage}%`
                   : '-',
               onClick: (row) => navigate(`/journals/${row.original.id}`),
-              size: 100,
+              size: 70,
             },
             {
               accessorKey: 'amount',

--- a/src/renderer/views/Journals/index.tsx
+++ b/src/renderer/views/Journals/index.tsx
@@ -292,6 +292,7 @@ const JournalsPage: React.FC<HasMiniView> = ({
           defaultSortField="date"
           defaultSortDirection="desc"
           virtual
+          virtualHeightMode={isMini ? 'content' : 'fill'}
           isMini={isMini}
           searchPlaceholder="Search journals…"
           searchFields={['id', 'narration', 'date', 'amount', 'billNumber']}

--- a/src/renderer/views/NewInvoice/hooks/useNewInvoiceColumns.tsx
+++ b/src/renderer/views/NewInvoice/hooks/useNewInvoiceColumns.tsx
@@ -246,8 +246,8 @@ export function useNewInvoiceColumns<T extends FieldValues>(
       },
       {
         header: 'Item',
-        size: 320,
-        minSize: 280,
+        size: 260,
+        minSize: 200,
         cell: ({ row }) => (
           <FormField
             control={form.control}
@@ -310,7 +310,7 @@ export function useNewInvoiceColumns<T extends FieldValues>(
       },
       {
         header: 'Quantity',
-        size: 180,
+        size: 140,
         minSize: 132,
         cell: ({ row }) => (
           <InvoiceLineQuantityCell<T>
@@ -367,9 +367,9 @@ export function useNewInvoiceColumns<T extends FieldValues>(
           ),
         },
         {
-          header: 'Discount',
-          size: isDiscountEditEnabled ? 150 : 75,
-          minSize: isDiscountEditEnabled ? 135 : 60,
+          header: 'Disc',
+          size: isDiscountEditEnabled ? 120 : 40,
+          minSize: isDiscountEditEnabled ? 102 : 36,
           cell: ({ row }) => (
             <FormField
               control={form.control}
@@ -429,6 +429,8 @@ export function useNewInvoiceColumns<T extends FieldValues>(
         },
         {
           header: 'Discounted Price',
+          size: 112,
+          minSize: 80,
           cell: ({ row }) => (
             <FormField
               control={form.control}

--- a/src/renderer/views/NewInvoice/index.tsx
+++ b/src/renderer/views/NewInvoice/index.tsx
@@ -2097,8 +2097,8 @@ const NewInvoicePage: React.FC<NewInvoiceProps> = ({
                 </section>
               </div>
 
-              <div className="flex flex-col gap-4 mt-8">
-                <h2 className="text-sm font-medium text-muted-foreground w-max mb-1">
+              <div className="flex flex-col gap-2">
+                <h2 className="text-sm font-medium text-muted-foreground w-max">
                   Line items
                 </h2>
                 {invoiceType === InvoiceType.Sale &&
@@ -2170,7 +2170,7 @@ const NewInvoicePage: React.FC<NewInvoiceProps> = ({
               {/* Invoice summary — always visible while scrolling line items */}
               {isSale && (
                 <section
-                  className="sticky bottom-0 z-10 mt-4 border-t bg-background/95 backdrop-blur-sm px-3 py-2 space-y-1.5"
+                  className="sticky -bottom-5 z-10 border-t bg-background/95 backdrop-blur-sm px-3 py-2 space-y-1.5"
                   aria-label="Invoice summary"
                 >
                   {isDiscountEditEnabled && (

--- a/src/renderer/views/Quotations/index.tsx
+++ b/src/renderer/views/Quotations/index.tsx
@@ -311,6 +311,7 @@ const QuotationsPage: FC<QuotationsPageProps> = ({
         defaultSortField="invoiceNumber"
         defaultSortDirection="desc"
         virtual
+        virtualHeightMode="fill"
         searchPlaceholder={`Search ${invoiceType.toLowerCase()} quotations...`}
         searchFields={[
           'invoiceNumber',

--- a/src/renderer/views/Reports/AccountBalances/index.tsx
+++ b/src/renderer/views/Reports/AccountBalances/index.tsx
@@ -204,7 +204,7 @@ const AccountBalancesPage = () => {
         </h1>
       </div>
 
-      <Card className="p-6 shadow-md print-card">
+      <Card className="shadow-md print-card">
         <AccountBalancesTable
           accountBalances={accountBalances}
           isLoading={isLoading}

--- a/src/renderer/views/Reports/AverageEquityBalances/index.tsx
+++ b/src/renderer/views/Reports/AverageEquityBalances/index.tsx
@@ -174,7 +174,7 @@ const AverageEquityBalancesPage = () => {
         </h1>
       </div>
 
-      <Card className="p-6 shadow-md print-card">
+      <Card className="shadow-md print-card">
         <AverageEquityBalancesTable
           items={sortedItems}
           totalAverage={state.totalAverage}

--- a/src/renderer/views/Reports/InventoryHealth/index.tsx
+++ b/src/renderer/views/Reports/InventoryHealth/index.tsx
@@ -878,6 +878,7 @@ const InventoryHealthPage: React.FC = () => {
               columns={columns}
               data={filteredTableData}
               virtual
+              virtualHeightMode="fill"
               compact
               defaultSortField="listPosition"
               defaultSortDirection="asc"

--- a/src/renderer/views/Reports/SalesPerformance/index.tsx
+++ b/src/renderer/views/Reports/SalesPerformance/index.tsx
@@ -1045,6 +1045,7 @@ const SalesPerformanceReportPage: React.FC = () => {
             searchPlaceholder="Search customers..."
             searchPersistenceKey={`${REPORT_FILTER_KEYS.salesPerformance}.customersSearch`}
             virtual
+            virtualHeightMode="fill"
           />
         )}
 
@@ -1058,6 +1059,7 @@ const SalesPerformanceReportPage: React.FC = () => {
             searchPlaceholder="Search items..."
             searchPersistenceKey={`${REPORT_FILTER_KEYS.salesPerformance}.itemsSearch`}
             virtual
+            virtualHeightMode="fill"
           />
         )}
 
@@ -1074,6 +1076,7 @@ const SalesPerformanceReportPage: React.FC = () => {
               searchPlaceholder="Search returns..."
               searchPersistenceKey={`${REPORT_FILTER_KEYS.salesPerformance}.returnsSearch`}
               virtual
+              virtualHeightMode="fill"
             />
           )}
 
@@ -1090,6 +1093,7 @@ const SalesPerformanceReportPage: React.FC = () => {
               searchPlaceholder="Search quotations..."
               searchPersistenceKey={`${REPORT_FILTER_KEYS.salesPerformance}.quotationsSearch`}
               virtual
+              virtualHeightMode="fill"
             />
           )}
 

--- a/src/renderer/views/Reports/StockAsOf/index.tsx
+++ b/src/renderer/views/Reports/StockAsOf/index.tsx
@@ -573,6 +573,7 @@ const StockAsOfReportPage: React.FC = () => {
           columns={columns}
           data={filteredTableData}
           virtual
+          virtualHeightMode="fill"
           compact
           defaultSortField="listPosition"
           defaultSortDirection="asc"

--- a/src/renderer/views/Reports/TrialBalance/index.tsx
+++ b/src/renderer/views/Reports/TrialBalance/index.tsx
@@ -192,7 +192,7 @@ const TrialBalancePage = () => {
         </div>
       }
     >
-      <Card className="flex min-h-0 flex-1 flex-col p-6 shadow-md print-card print:flex-none">
+      <Card className="flex min-h-0 flex-1 flex-col shadow-md print-card print:flex-none">
         {!trialBalance.isBalanced && (
           <div className="mb-4 p-3 bg-destructive/10 border border-destructive rounded-md text-sm text-destructive print:hidden">
             Trial balance is not balanced! Difference:{' '}


### PR DESCRIPTION
## Describe your changes

### Screenshots [Optional]

## Issue ticket number and link

Closes #

## Checklist before requesting a review

- [x] I have bumped version in package.json files.
- [ ] I have confirmed that it works on Mac and Windows.
- [ ] I have added tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared `DataTable` virtualization sizing logic used across many listing/report screens, which could affect scroll/height behavior and performance in multiple views. Mostly UI/layout tweaks, but wide surface area means regressions are possible on different window sizes.
> 
> **Overview**
> Adds a new `DataTable` prop, `virtualHeightMode`, to control virtualized table height as either **shrink-to-content** or **fill-viewport**, replacing the previous ad-hoc resize/height state with a `useSyncExternalStore` window-height snapshot and clamped height calculations.
> 
> Updates most virtualized list/report screens (accounts, invoices, journals, quotations, inventory, ledger, and several reports) to use `virtualHeightMode="fill"` (or `content` for mini views) so tables better utilize available space.
> 
> Makes additional compact-layout adjustments: narrows several New Invoice line-item columns/headers and tweaks spacing/sticky summary positioning, and removes extra `Card` padding in a few report pages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 313522ea9f4891fe9d272007941f151313e1efe1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->